### PR TITLE
[FEATURE] Add config option to overwrite existing target file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ autoload:
   dropComposerAutoload: true
   targetFile: 'ext_emconf.php'
   backupSources: false
+  overwriteExistingTargetFile: false
 pathToVendorLibraries: 'Resources/Private/Libs'
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ composer bundle-autoload \
     [-a|--[no-]drop-composer-autoload] \
     [-t|--target-file TARGET-FILE] \
     [-b|--[no-]backup-sources] \
-    [-f|--force]
+    [-o|--[no-]overwrite]
 ```
 
 Pass the following options to the console command:
@@ -80,7 +80,11 @@ generated.
 > [!NOTE]
 > If omitted, the `autoload.backupSources` option from the config file will be used instead.
 
-### `-f|--force`
+### `-o|--[no-]overwrite`
 
-Force overwriting the given target file if it already exists. When omitted, you will be
-asked whether the target file should be overwritten.
+Force overwriting the given target file if it already exists.
+
+> [!NOTE]
+> If omitted, the `autoload.overwriteExistingTargetFile` option from the config file will be
+> used instead. If `false` is configured, you will be asked whether the target file should be
+> overwritten.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -7,6 +7,7 @@ autoload:
   dropComposerAutoload: true
   targetFile: 'ext_emconf.php'
   backupSources: false
+  overwriteExistingTargetFile: false
 
 # Path to composer.json where vendor libraries are managed
 pathToVendorLibraries: 'Resources/Private/Libs'
@@ -20,12 +21,13 @@ rootPath: ../
 
 ## Autoload
 
-| Property                        | Type    | Required | Description                                                                       |
-|---------------------------------|---------|----------|-----------------------------------------------------------------------------------|
-| `autoload`                      | Object  | –        | Set of configuration options to respect when bundling autoload configuration.     |
-| `autoload.dropComposerAutoload` | Boolean | –        | Define whether to drop `autoload` section in `composer.json`. Defaults to `true`. |
-| `autoload.targetFile`           | String  | –        | File where to bundle autoload configuration. Defaults to `ext_emconf.php`.        |
-| `autoload.backupSources`        | Boolean | –        | Define whether to backup source files. Defaults to `false`.                       |
+| Property                               | Type    | Required | Description                                                                             |
+|----------------------------------------|---------|----------|-----------------------------------------------------------------------------------------|
+| `autoload`                             | Object  | –        | Set of configuration options to respect when bundling autoload configuration.           |
+| `autoload.dropComposerAutoload`        | Boolean | –        | Define whether to drop `autoload` section in `composer.json`. Defaults to `true`.       |
+| `autoload.targetFile`                  | String  | –        | File where to bundle autoload configuration. Defaults to `ext_emconf.php`.              |
+| `autoload.backupSources`               | Boolean | –        | Define whether to backup source files. Defaults to `false`.                             |
+| `autoload.overwriteExistingTargetFile` | Boolean | –        | Define whether to overwrite the target file, if it already exists. Defaults to `false`. |
 
 ## Path to vendor libraries
 

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -40,6 +40,12 @@
 					"title": "Define whether to backup source files",
 					"description": "When enabled, original contents of source files, which are to be modified, will be backed up in a separate file",
 					"default": false
+				},
+				"overwriteExistingTargetFile": {
+					"type": "boolean",
+					"title": "Define whether to overwrite the target file, if it already exists",
+					"description": "When enabled, the configured target file will be overwritten with the bundled autoload information, if the file already exists",
+					"default": false
 				}
 			},
 			"additionalProperties": false

--- a/src/Command/BundleAutoloadCommand.php
+++ b/src/Command/BundleAutoloadCommand.php
@@ -77,10 +77,10 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
             'Backup source files before they get overwritten',
         );
         $this->addOption(
-            'force',
-            'f',
-            Console\Input\InputOption::VALUE_NONE,
-            'Force overwriting the given target file',
+            'overwrite',
+            'o',
+            Console\Input\InputOption::VALUE_NONE | Console\Input\InputOption::VALUE_NEGATABLE,
+            'Force overwriting the given target file, if it already exists',
         );
     }
 
@@ -104,7 +104,7 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
         $dropComposerAutoload = $input->getOption('drop-composer-autoload') ?? $config->autoload()->dropComposerAutoload();
         $targetFile = $input->getOption('target-file') ?? $config->autoload()->targetFile();
         $backupSources = $input->getOption('backup-sources') ?? $config->autoload()->backupSources();
-        $force = $input->getOption('force');
+        $overwrite = $input->getOption('overwrite') ?? $config->autoload()->overwriteExistingTargetFile();
 
         // Exit if libs directory is invalid
         if ('' === trim($libsDir)) {
@@ -116,9 +116,9 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
         $autoloadBundler = new Bundler\AutoloadBundler($rootPath, $libsDir, $this->io);
 
         try {
-            $autoload = $autoloadBundler->bundle($targetFile, $dropComposerAutoload, $backupSources, $force);
+            $autoload = $autoloadBundler->bundle($targetFile, $dropComposerAutoload, $backupSources, $overwrite);
         } catch (Exception\FileAlreadyExists $exception) {
-            if (!$this->io->confirm('Target file already exists. Overwrite file?')) {
+            if (!$this->io->confirm('Target file already exists. Overwrite file?', false)) {
                 throw $exception;
             }
 

--- a/src/Config/AutoloadConfig.php
+++ b/src/Config/AutoloadConfig.php
@@ -35,6 +35,7 @@ final readonly class AutoloadConfig
         private bool $dropComposerAutoload = true,
         private string $targetFile = 'ext_emconf.php',
         private bool $backupSources = false,
+        private bool $overwriteExistingTargetFile = false,
     ) {}
 
     public function dropComposerAutoload(): bool
@@ -50,5 +51,10 @@ final readonly class AutoloadConfig
     public function backupSources(): bool
     {
         return $this->backupSources;
+    }
+
+    public function overwriteExistingTargetFile(): bool
+    {
+        return $this->overwriteExistingTargetFile;
     }
 }

--- a/tests/src/Command/BundleAutoloadCommandTest.php
+++ b/tests/src/Command/BundleAutoloadCommandTest.php
@@ -139,7 +139,7 @@ final class BundleAutoloadCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function executeOverwritesTargetWithoutAskingIfForceOptionIsSet(): void
+    public function executeOverwritesTargetWithoutAskingIfOverwriteOptionIsSet(): void
     {
         $rootPath = dirname(__DIR__).'/Fixtures/Extensions/valid';
 
@@ -151,7 +151,7 @@ final class BundleAutoloadCommandTest extends Framework\TestCase
 
         $this->commandTester->execute([
             '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
-            '--force' => true,
+            '--overwrite' => true,
         ]);
 
         self::assertStringNotEqualsFile($rootPath.'/ext_emconf_modified.php', '');
@@ -188,6 +188,7 @@ final class BundleAutoloadCommandTest extends Framework\TestCase
         $this->commandTester->execute([
             '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
             '--drop-composer-autoload' => true,
+            '--overwrite' => true,
         ]);
 
         self::assertJsonStringEqualsJsonFile($rootPath.'/composer.json', '{}');
@@ -230,6 +231,7 @@ final class BundleAutoloadCommandTest extends Framework\TestCase
             '--drop-composer-autoload' => true,
             '--target-file' => 'ext_emconf.php',
             '--backup-sources' => false,
+            '--overwrite' => true,
         ]);
 
         self::assertFileDoesNotExist($rootPath.'/composer.json.bak');


### PR DESCRIPTION
A new `autoload.overwriteExistingTargetFile` config option is added. In addition, the `--force` command option of the `composer bundle-autoload` command is renamed to `--overwrite` and now falls back to the config option, if omitted.