### PR TITLE
[FEATURE] Allow to exclude paths from vendor class map

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ autoload:
   targetFile: 'ext_emconf.php'
   backupSources: false
   overwriteExistingTargetFile: false
+  excludeFromClassMap:
+    - 'vendor/composer/InstalledVersions.php'
 pathToVendorLibraries: 'Resources/Private/Libs'
 ```
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -8,6 +8,8 @@ autoload:
   targetFile: 'ext_emconf.php'
   backupSources: false
   overwriteExistingTargetFile: false
+  excludeFromClassMap:
+    - 'vendor/composer/InstalledVersions.php'
 
 # Path to composer.json where vendor libraries are managed
 pathToVendorLibraries: 'Resources/Private/Libs'
@@ -28,6 +30,7 @@ rootPath: ../
 | `autoload.targetFile`                  | String  | –        | File where to bundle autoload configuration. Defaults to `ext_emconf.php`.              |
 | `autoload.backupSources`               | Boolean | –        | Define whether to backup source files. Defaults to `false`.                             |
 | `autoload.overwriteExistingTargetFile` | Boolean | –        | Define whether to overwrite the target file, if it already exists. Defaults to `false`. |
+| `autoload.excludeFromClassMap`         | Array   | –        | List of files to exclude from vendor libraries class map.                               |
 
 ## Path to vendor libraries
 

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -46,6 +46,15 @@
 					"title": "Define whether to overwrite the target file, if it already exists",
 					"description": "When enabled, the configured target file will be overwritten with the bundled autoload information, if the file already exists",
 					"default": false
+				},
+				"excludeFromClassMap": {
+					"type": "array",
+					"title": "List of files to exclude from vendor libraries class map",
+					"description": "Absolute or relative paths to files to remove from parsed vendor libraries class map",
+					"items": {
+						"type": "string",
+						"minLength": 1
+					}
 				}
 			},
 			"additionalProperties": false

--- a/src/Bundler/Entity/ClassMap.php
+++ b/src/Bundler/Entity/ClassMap.php
@@ -25,8 +25,11 @@ namespace EliasHaeussler\Typo3VendorBundler\Bundler\Entity;
 
 use Symfony\Component\Filesystem;
 
+use function array_diff;
 use function array_map;
 use function array_merge;
+use function array_values;
+use function in_array;
 
 /**
  * ClassMap.
@@ -61,6 +64,28 @@ final readonly class ClassMap extends PathAwareBundle
             $map,
         );
         $this->filename = $this->convertToAbsolutePath($filename);
+    }
+
+    public function has(string $path): bool
+    {
+        $fullPath = $this->convertToAbsolutePath($path);
+
+        return in_array($fullPath, $this->map, true);
+    }
+
+    public function remove(string $path): self
+    {
+        $fullPath = $this->convertToAbsolutePath($path);
+
+        if (!$this->has($fullPath)) {
+            return $this;
+        }
+
+        return new self(
+            array_values(array_diff($this->map, [$fullPath])),
+            $this->filename,
+            $this->rootPath,
+        );
     }
 
     /**

--- a/src/Command/BundleAutoloadCommand.php
+++ b/src/Command/BundleAutoloadCommand.php
@@ -105,6 +105,7 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
         $targetFile = $input->getOption('target-file') ?? $config->autoload()->targetFile();
         $backupSources = $input->getOption('backup-sources') ?? $config->autoload()->backupSources();
         $overwrite = $input->getOption('overwrite') ?? $config->autoload()->overwriteExistingTargetFile();
+        $excludeFromClassMap = $config->autoload()->excludeFromClassMap();
 
         // Exit if libs directory is invalid
         if ('' === trim($libsDir)) {
@@ -116,13 +117,25 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
         $autoloadBundler = new Bundler\AutoloadBundler($rootPath, $libsDir, $this->io);
 
         try {
-            $autoload = $autoloadBundler->bundle($targetFile, $dropComposerAutoload, $backupSources, $overwrite);
+            $autoload = $autoloadBundler->bundle(
+                $targetFile,
+                $dropComposerAutoload,
+                $backupSources,
+                $overwrite,
+                $excludeFromClassMap,
+            );
         } catch (Exception\FileAlreadyExists $exception) {
             if (!$this->io->confirm('Target file already exists. Overwrite file?', false)) {
                 throw $exception;
             }
 
-            $autoload = $autoloadBundler->bundle($targetFile, $dropComposerAutoload, $backupSources, true);
+            $autoload = $autoloadBundler->bundle(
+                $targetFile,
+                $dropComposerAutoload,
+                $backupSources,
+                true,
+                $excludeFromClassMap,
+            );
         }
 
         $this->io->success(

--- a/src/Config/AutoloadConfig.php
+++ b/src/Config/AutoloadConfig.php
@@ -31,11 +31,15 @@ namespace EliasHaeussler\Typo3VendorBundler\Config;
  */
 final readonly class AutoloadConfig
 {
+    /**
+     * @param list<non-empty-string> $excludeFromClassMap
+     */
     public function __construct(
         private bool $dropComposerAutoload = true,
         private string $targetFile = 'ext_emconf.php',
         private bool $backupSources = false,
         private bool $overwriteExistingTargetFile = false,
+        private array $excludeFromClassMap = [],
     ) {}
 
     public function dropComposerAutoload(): bool
@@ -56,5 +60,13 @@ final readonly class AutoloadConfig
     public function overwriteExistingTargetFile(): bool
     {
         return $this->overwriteExistingTargetFile;
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public function excludeFromClassMap(): array
+    {
+        return $this->excludeFromClassMap;
     }
 }

--- a/src/Console/Output/TaskRunner.php
+++ b/src/Console/Output/TaskRunner.php
@@ -42,7 +42,7 @@ final readonly class TaskRunner
     /**
      * @template T
      *
-     * @param Closure(): T                                $task
+     * @param Closure(bool): T                            $task
      * @param Console\Output\OutputInterface::VERBOSITY_* $verbosity
      *
      * @return T
@@ -52,12 +52,19 @@ final readonly class TaskRunner
         Closure $task,
         int $verbosity = Console\Output\OutputInterface::VERBOSITY_NORMAL,
     ): mixed {
+        $successful = true;
+
         $this->output->write($message.'... ', false, $verbosity);
 
         try {
-            $result = $task();
+            $result = $task($successful);
 
-            $this->output->writeln('<info>Done</info>', $verbosity);
+            /* @phpstan-ignore if.alwaysTrue */
+            if ($successful) {
+                $this->output->writeln('<info>Done</info>', $verbosity);
+            } else {
+                $this->output->writeln('<error>Failed</error>', $verbosity);
+            }
 
             return $result;
         } catch (Throwable $exception) {

--- a/tests/src/Bundler/Entity/ClassMapTest.php
+++ b/tests/src/Bundler/Entity/ClassMapTest.php
@@ -52,6 +52,45 @@ final class ClassMapTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function hasReturnsTrueIfGivenRelativePathExistsInMap(): void
+    {
+        self::assertTrue($this->subject->has('foo'));
+        self::assertTrue($this->subject->has('foo/baz'));
+        self::assertFalse($this->subject->has('baz'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function hasReturnsTrueIfGivenAbsolutePathExistsInMap(): void
+    {
+        self::assertTrue($this->subject->has(__DIR__.'/foo'));
+        self::assertTrue($this->subject->has(__DIR__.'/foo/baz'));
+        self::assertFalse($this->subject->has(__DIR__.'/baz'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeDoesNothingIfGivenPathDoesNotExistInMap(): void
+    {
+        $expected = $this->subject->toArray();
+
+        self::assertSame($this->subject, $this->subject->remove('baz'));
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeReturnsNewClassMapObjectWithoutGivenPath(): void
+    {
+        $expected = new Src\Bundler\Entity\ClassMap(
+            [
+                'foo/baz',
+            ],
+            'classmap.php',
+            __DIR__,
+        );
+
+        self::assertEquals($expected, $this->subject->remove('foo'));
+    }
+
+    #[Framework\Attributes\Test]
     public function toArrayReturnsClassMap(): void
     {
         $expected = [

--- a/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
@@ -1,4 +1,6 @@
 autoload:
   dropComposerAutoload: false
   targetFile: 'ext_emconf_modified.php'
+  excludeFromClassMap:
+    - 'vendor/composer/InstalledVersions.php'
 pathToVendorLibraries: 'libs'


### PR DESCRIPTION
Single paths can now be excluded from the vendor libraries class map, using the `autoload.excludeFromClassMap` config option.