### PR TITLE
[!!!][FEATURE] Add support for Composer as target manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /tests/src/Fixtures/Extensions/*/libs/vendor
 /tests/src/Fixtures/Extensions/*/libs/composer.lock
 /tests/src/Fixtures/Extensions/*/composer.json.bak
+/tests/src/Fixtures/Extensions/*/composer_modified.json
 /tests/src/Fixtures/Extensions/*/ext_emconf.php.bak
 /tests/src/Fixtures/Extensions/*/ext_emconf_modified.php
 /tests/src/Fixtures/Extensions/valid-temporary

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Add a `typo3-vendor-bundler.yaml` config file:
 # typo3-vendor-bundler.yaml
 
 autoload:
-  dropComposerAutoload: true
-  targetFile: 'ext_emconf.php'
+  target:
+    file: 'composer.json'
+    manifest: 'composer'
+    overwrite: true
   backupSources: false
-  overwriteExistingTargetFile: false
   excludeFromClassMap:
     - 'vendor/composer/InstalledVersions.php'
 pathToVendorLibraries: 'Resources/Private/Libs'

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,9 @@ $autoloadBundler = new Typo3VendorBundler\Bundler\AutoloadBundler(
     $librariesPath,
     new \Symfony\Component\Console\Output\ConsoleOutput(),
 );
-$autoloadBundle = $autoloadBundler->bundle('ext_emconf.php');
+$autoloadBundle = $autoloadBundler->bundle(
+    Typo3VendorBundler\Config\AutoloadTarget::composer(),
+);
 
 // Display results
 echo 'Autoload configuration was bundled and dumped to '.$autoloadBundle->filename();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ working directory.
 
 ## [`bundle-autoload`](../src/Command/BundleAutoloadCommand.php)
 
-Bundles autoloader for vendor libraries in `ext_emconf.php`.
+Bundles autoloader for vendor libraries in `composer.json` or `ext_emconf.php`.
 
 ```bash
 composer bundle-autoload \
@@ -25,6 +25,7 @@ composer bundle-autoload \
     [-c|--config CONFIG] \
     [-a|--[no-]drop-composer-autoload] \
     [-t|--target-file TARGET-FILE] \
+    [-m|--target-manifest TARGET-MANIFEST] \
     [-b|--[no-]backup-sources] \
     [-o|--[no-]overwrite]
 ```
@@ -53,9 +54,10 @@ the section will be removed in order to let `ext_emconf.php` manage all autoload
 parameters.
 
 > [!IMPORTANT]
-> You should always drop the `autoload` section from `composer.json`. Otherwise,
-> TYPO3 won't read configured `autoload` configuration from `ext_emconf.php` in
-> classic mode.
+> This option is not available when using the `composer` target manifest. When
+> using the `extEmConf` target manifest, you should always drop the `autoload`
+> section from `composer.json`. Otherwise, TYPO3 won't read configured `autoload`
+> configuration from `ext_emconf.php` in classic mode.
 
 > [!NOTE]
 > If omitted, the `autoload.dropComposerAutoload` option from the config file
@@ -63,12 +65,22 @@ parameters.
 
 ### `t|--target-file`
 
-File where to bundle final autoload configuration. This is usually the `ext_emconf.php`
-file, but you can also use a different file, especially for debugging and testing
-purposes.
+File where to bundle final autoload configuration. This is usually the `composer.json`
+file when using the `composer` target manifest or `ext_emconf.php` file when using
+the `extEmConf` target manifest. You can also use a different file, especially for
+debugging and testing purposes.
 
 > [!NOTE]
-> If omitted, the `autoload.targetFile` option from the config file will be used instead.
+> If omitted, the `autoload.target.file` option from the config file will be used instead.
+
+### `-m|--target-manifest`
+
+The manifest which decides how to dump bundled autoload configuration. Can be `composer`
+(default) or `extEmConf`.
+
+> [!NOTE]
+> If omitted, the `autoload.target.manifest` option from the config file will be used
+> instead.
 
 ### `-b|--[no-]backup-sources`
 
@@ -85,6 +97,5 @@ generated.
 Force overwriting the given target file if it already exists.
 
 > [!NOTE]
-> If omitted, the `autoload.overwriteExistingTargetFile` option from the config file will be
-> used instead. If `false` is configured, you will be asked whether the target file should be
-> overwritten.
+> If omitted, the `autoload.target.overwrite` option from the config file will be used instead.
+> If `false` is configured, you will be asked whether the target file should be overwritten.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -5,9 +5,11 @@ The config file must follow a given schema:
 ```yaml
 autoload:
   dropComposerAutoload: true
-  targetFile: 'ext_emconf.php'
+  target:
+    file: 'composer.json'
+    manifest: 'composer'
+    overwrite: false
   backupSources: false
-  overwriteExistingTargetFile: false
   excludeFromClassMap:
     - 'vendor/composer/InstalledVersions.php'
 
@@ -23,14 +25,16 @@ rootPath: ../
 
 ## Autoload
 
-| Property                               | Type    | Required | Description                                                                             |
-|----------------------------------------|---------|----------|-----------------------------------------------------------------------------------------|
-| `autoload`                             | Object  | –        | Set of configuration options to respect when bundling autoload configuration.           |
-| `autoload.dropComposerAutoload`        | Boolean | –        | Define whether to drop `autoload` section in `composer.json`. Defaults to `true`.       |
-| `autoload.targetFile`                  | String  | –        | File where to bundle autoload configuration. Defaults to `ext_emconf.php`.              |
-| `autoload.backupSources`               | Boolean | –        | Define whether to backup source files. Defaults to `false`.                             |
-| `autoload.overwriteExistingTargetFile` | Boolean | –        | Define whether to overwrite the target file, if it already exists. Defaults to `false`. |
-| `autoload.excludeFromClassMap`         | Array   | –        | List of files to exclude from vendor libraries class map.                               |
+| Property                        | Type    | Required | Description                                                                                |
+|---------------------------------|---------|----------|--------------------------------------------------------------------------------------------|
+| `autoload`                      | Object  | –        | Set of configuration options to respect when bundling autoload configuration.              |
+| `autoload.dropComposerAutoload` | Boolean | –        | Define whether to drop `autoload` section in `composer.json`. Defaults to `true`.          |
+| `autoload.target`               | Object  | –        | Set of configuration options related to the bundle target.                                 |
+| `autoload.target.file`          | String  | –        | File where to bundle autoload configuration. Defaults to `composer.json`.                  |
+| `autoload.target.manifest`      | String  | –        | Manifest which decides how to dump bundled autoload configuration. Defaults to `composer`. |
+| `autoload.target.overwrite`     | Boolean | –        | Define whether to overwrite the target file, if it already exists. Defaults to `false`.    |
+| `autoload.backupSources`        | Boolean | –        | Define whether to backup source files. Defaults to `false`.                                |
+| `autoload.excludeFromClassMap`  | Array   | –        | List of files to exclude from vendor libraries class map.                                  |
 
 ## Path to vendor libraries
 

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -32,8 +32,18 @@
 				"targetFile": {
 					"type": "string",
 					"title": "File where to bundle autoload configuration",
-					"description": "This is usually the `ext_emconf.php` file",
-					"default": "ext_emconf.php"
+					"description": "This is usually the `composer.json` or `ext_emconf.php` file",
+					"default": "composer.json"
+				},
+				"targetManifest": {
+					"type": "string",
+					"enum": [
+						"composer",
+						"extEmConf"
+					],
+					"title": "Target manifest where to bundle autoload configuration",
+					"description": "Can be either \"composer\" (targeting `composer.json` file, default) or \"extEmConf\" (targeting `ext_emconf.php` file)",
+					"default": "composer"
 				},
 				"backupSources": {
 					"type": "boolean",

--- a/src/Bundler/Entity/Manifest.php
+++ b/src/Bundler/Entity/Manifest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-vendor-bundler".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3VendorBundler\Bundler\Entity;
+
+/**
+ * Manifest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+enum Manifest: string
+{
+    case Composer = 'composer';
+    case ExtEmConf = 'extEmConf';
+}

--- a/src/Config/AutoloadTarget.php
+++ b/src/Config/AutoloadTarget.php
@@ -26,47 +26,41 @@ namespace EliasHaeussler\Typo3VendorBundler\Config;
 use EliasHaeussler\Typo3VendorBundler\Bundler;
 
 /**
- * AutoloadConfig.
+ * AutoloadTarget.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final readonly class AutoloadConfig
+final readonly class AutoloadTarget
 {
-    /**
-     * @param list<non-empty-string> $excludeFromClassMap
-     */
     public function __construct(
-        private bool $dropComposerAutoload = true,
-        private AutoloadTarget $target = new AutoloadTarget(),
-        private bool $backupSources = false,
-        private array $excludeFromClassMap = [],
+        private string $file = 'composer.json',
+        private Bundler\Entity\Manifest $manifest = Bundler\Entity\Manifest::Composer,
+        private bool $overwrite = false,
     ) {}
 
-    public function dropComposerAutoload(): bool
+    public static function composer(string $file = 'composer.json', bool $overwrite = false): self
     {
-        if (Bundler\Entity\Manifest::Composer === $this->target->manifest()) {
-            return false;
-        }
-
-        return $this->dropComposerAutoload;
+        return new self($file, Bundler\Entity\Manifest::Composer, $overwrite);
     }
 
-    public function target(): AutoloadTarget
+    public static function extEmConf(string $file = 'ext_emconf.php', bool $overwrite = false): self
     {
-        return $this->target;
+        return new self($file, Bundler\Entity\Manifest::ExtEmConf, $overwrite);
     }
 
-    public function backupSources(): bool
+    public function file(): string
     {
-        return $this->backupSources;
+        return $this->file;
     }
 
-    /**
-     * @return list<non-empty-string>
-     */
-    public function excludeFromClassMap(): array
+    public function manifest(): Bundler\Entity\Manifest
     {
-        return $this->excludeFromClassMap;
+        return $this->manifest;
+    }
+
+    public function overwrite(): bool
+    {
+        return $this->overwrite;
     }
 }

--- a/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
@@ -1,6 +1,8 @@
 autoload:
   dropComposerAutoload: false
-  targetFile: 'ext_emconf_modified.php'
+  target:
+    file: 'ext_emconf_modified.php'
+    manifest: 'extEmConf'
   excludeFromClassMap:
     - 'vendor/composer/InstalledVersions.php'
 pathToVendorLibraries: 'libs'


### PR DESCRIPTION
This PR adds support for `composer.json` files as target manifest. It allows to bundle autoload configuration in an existing `composer.json`, taking libraries and `ext_emconf.php` into account.

> [!IMPORTANT]
> With this PR, autoload bundling now defaults to `composer.json` files. The previous behavior can be restored by configuring the target manifest as `extEmConf`.