### PR TITLE
[BUGFIX] Allow distinguishing defaults from user configuration

### DIFF
--- a/src/Bundler/AutoloadBundler.php
+++ b/src/Bundler/AutoloadBundler.php
@@ -93,18 +93,18 @@ final readonly class AutoloadBundler implements Bundler
      */
     public function bundle(
         Config\AutoloadTarget $target = new Config\AutoloadTarget(),
-        bool $dropComposerAutoload = true,
-        bool $backupSources = false,
+        ?bool $dropComposerAutoload = null,
+        ?bool $backupSources = null,
         array $excludeFromClassMap = [],
     ): Entity\Autoload {
         $config = new Config\AutoloadConfig(
-            $dropComposerAutoload,
+            $dropComposerAutoload ?? true,
             new Config\AutoloadTarget(
                 Filesystem\Path::makeAbsolute($target->file(), $this->rootPath),
                 $target->manifest(),
                 $target->overwrite(),
             ),
-            $backupSources,
+            $backupSources ?? false,
             $excludeFromClassMap,
         );
 
@@ -132,12 +132,12 @@ final readonly class AutoloadBundler implements Bundler
         $autoload = new Entity\Autoload($classMap, $psr4Namespaces, $config->target()->file(), $this->rootPath);
 
         // Throw exception if target file already exists
-        if (!$config->target()->overwrite() && $this->filesystem->exists($config->target()->file())) {
+        if (true !== $config->target()->overwrite() && $this->filesystem->exists($config->target()->file())) {
             throw new Exception\FileAlreadyExists($config->target()->file());
         }
 
         // Create composer.json backup
-        if ($config->backupSources()) {
+        if (true === $config->backupSources()) {
             $this->taskRunner->run(
                 '🦖 Backing up source files',
                 function () use ($config) {
@@ -197,12 +197,12 @@ final readonly class AutoloadBundler implements Bundler
         $extEmConf['autoload'] = $autoload->toArray(true);
 
         // Throw exception if target file already exists
-        if (!$config->target()->overwrite() && $this->filesystem->exists($config->target()->file())) {
+        if (true !== $config->target()->overwrite() && $this->filesystem->exists($config->target()->file())) {
             throw new Exception\FileAlreadyExists($config->target()->file());
         }
 
         // Create ext_emconf.php backup
-        if ($config->backupSources()) {
+        if (true === $config->backupSources()) {
             $this->taskRunner->run(
                 '🦖 Backing up source files',
                 function () use ($config, $declarationFile) {
@@ -210,7 +210,7 @@ final readonly class AutoloadBundler implements Bundler
                         $this->filesystem->copy($declarationFile, $declarationFile.'.bak');
                     }
 
-                    if ($config->dropComposerAutoload()) {
+                    if (true === $config->dropComposerAutoload()) {
                         $composerJson = Filesystem\Path::join($this->rootPath, 'composer.json');
 
                         $this->filesystem->copy($composerJson, $composerJson.'.bak');
@@ -235,7 +235,7 @@ PHP;
         );
 
         // Remove autoload section from root composer.json
-        if ($config->dropComposerAutoload()) {
+        if (true === $config->dropComposerAutoload()) {
             $this->taskRunner->run(
                 '✂️ Removing autoload section from composer.json',
                 function () {

--- a/src/Config/AutoloadConfig.php
+++ b/src/Config/AutoloadConfig.php
@@ -37,13 +37,13 @@ final readonly class AutoloadConfig
      * @param list<non-empty-string> $excludeFromClassMap
      */
     public function __construct(
-        private bool $dropComposerAutoload = true,
+        private ?bool $dropComposerAutoload = null,
         private AutoloadTarget $target = new AutoloadTarget(),
-        private bool $backupSources = false,
+        private ?bool $backupSources = null,
         private array $excludeFromClassMap = [],
     ) {}
 
-    public function dropComposerAutoload(): bool
+    public function dropComposerAutoload(): ?bool
     {
         if (Bundler\Entity\Manifest::Composer === $this->target->manifest()) {
             return false;
@@ -57,7 +57,7 @@ final readonly class AutoloadConfig
         return $this->target;
     }
 
-    public function backupSources(): bool
+    public function backupSources(): ?bool
     {
         return $this->backupSources;
     }

--- a/src/Config/AutoloadTarget.php
+++ b/src/Config/AutoloadTarget.php
@@ -36,7 +36,7 @@ final readonly class AutoloadTarget
     public function __construct(
         private string $file = 'composer.json',
         private Bundler\Entity\Manifest $manifest = Bundler\Entity\Manifest::Composer,
-        private bool $overwrite = false,
+        private ?bool $overwrite = null,
     ) {}
 
     public static function composer(string $file = 'composer.json', bool $overwrite = false): self
@@ -59,7 +59,7 @@ final readonly class AutoloadTarget
         return $this->manifest;
     }
 
-    public function overwrite(): bool
+    public function overwrite(): ?bool
     {
         return $this->overwrite;
     }


### PR DESCRIPTION
This change widens all boolean config values to default to `null`. This allows to better distinguish from "empty" config and manual user configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated bundler configuration parameters to use explicit null semantics, ensuring more consistent and predictable handling of default values across autoload bundling operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->