### PR TITLE
[BUGFIX] Respect `--no-overwrite` input when file already exists

### DIFF
--- a/src/Command/BundleAutoloadCommand.php
+++ b/src/Command/BundleAutoloadCommand.php
@@ -131,7 +131,9 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
             $target = new Config\AutoloadTarget($targetFile, $targetManifest, $overwrite);
             $autoload = $autoloadBundler->bundle($target, $dropComposerAutoload, $backupSources, $excludeFromClassMap);
         } catch (Exception\FileAlreadyExists $exception) {
-            if (!$this->io->confirm('Target file already exists. Overwrite file?', false)) {
+            if (false === $input->getOption('overwrite')
+                || !$this->io->confirm('Target file already exists. Overwrite file?', false)
+            ) {
                 throw $exception;
             }
 

--- a/tests/src/Command/BundleAutoloadCommandTest.php
+++ b/tests/src/Command/BundleAutoloadCommandTest.php
@@ -99,7 +99,42 @@ final class BundleAutoloadCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function executeThrowsExceptionIfTargetFileAlreadyExistsAndShouldNotBeOverwritten(): void
+    public function executeThrowsExceptionIfTargetFileAlreadyExistsAndShouldNotBeOverwrittenAsPerInputOption(): void
+    {
+        $rootPath = dirname(__DIR__).'/Fixtures/Extensions/valid';
+
+        // Make sure file exists
+        $this->filesystem->touch($rootPath.'/ext_emconf_modified.php');
+
+        $this->expectExceptionObject(
+            new Src\Exception\FileAlreadyExists($rootPath.'/ext_emconf_modified.php'),
+        );
+
+        $this->commandTester->execute([
+            '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
+            '--overwrite' => false,
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeThrowsExceptionIfTargetFileAlreadyExistsAndShouldNotBeOverwrittenAsPerConfiguration(): void
+    {
+        $rootPath = dirname(__DIR__).'/Fixtures/Extensions/valid';
+
+        // Make sure file exists
+        $this->filesystem->touch($rootPath.'/ext_emconf_modified.php');
+
+        $this->expectExceptionObject(
+            new Src\Exception\FileAlreadyExists($rootPath.'/ext_emconf_modified.php'),
+        );
+
+        $this->commandTester->execute([
+            '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeThrowsExceptionIfTargetFileAlreadyExistsAndShouldNotBeOverwrittenAsPerUserInput(): void
     {
         $rootPath = dirname(__DIR__).'/Fixtures/Extensions/valid';
 

--- a/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/valid/typo3-vendor-bundler.yaml
@@ -3,6 +3,7 @@ autoload:
   target:
     file: 'ext_emconf_modified.php'
     manifest: 'extEmConf'
+    overwrite: false
   excludeFromClassMap:
     - 'vendor/composer/InstalledVersions.php'
 pathToVendorLibraries: 'libs'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--overwrite` command-line option to control handling of existing vendor manifest files during bundling.
  * Introduced configuration-based overwrite setting for autoload targets in manifest files.
  * Enhanced bundling process with user confirmation prompts when overwrite behavior is not explicitly specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->