### PR TITLE
[TASK] Reflect removed `ext_emconf.php` support in various places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 /tests/src/Fixtures/Extensions/*/libs/sbom_generated.json
 /tests/src/Fixtures/Extensions/*/composer.json.bak
 /tests/src/Fixtures/Extensions/*/composer_modified.json
-/tests/src/Fixtures/Extensions/*/ext_emconf.php.bak
 /tests/src/Fixtures/Extensions/valid-temporary
 /vendor/

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,8 @@ working directory.
 
 ## [`bundle-autoload`](../src/Command/BundleAutoloadCommand.php)
 
-Bundles autoloader for vendor libraries in `composer.json` or `ext_emconf.php`.
+Bundles autoloader for vendor libraries in `composer.json` file of
+the extension.
 
 ```bash
 composer bundle-autoload \
@@ -56,7 +57,7 @@ debugging and testing purposes.
 
 ### `-b|--[no-]backup-sources`
 
-Define whether to backup source files (normally `composer.json` and `ext_emconf.php`).
+Define whether to backup source files (normally the root `composer.json` file of the extension).
 When enabled, original contents of source files, which are to be modified, will be backed
 up in a separate file. If no contents would be modified, no backup files will be
 generated.

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -54,7 +54,7 @@
 				"file": {
 					"type": "string",
 					"title": "File where to bundle autoload configuration",
-					"description": "This is usually the `composer.json` or `ext_emconf.php` file",
+					"description": "This is usually the root `composer.json` file of an extension",
 					"default": "composer.json"
 				},
 				"overwrite": {

--- a/src/Command/BundleAutoloadCommand.php
+++ b/src/Command/BundleAutoloadCommand.php
@@ -50,7 +50,7 @@ final class BundleAutoloadCommand extends AbstractConfigurationAwareCommand
     {
         parent::configure();
 
-        $this->setDescription('Bundle autoloader for vendor libraries in composer.json or ext_emconf.php');
+        $this->setDescription('Bundle autoloader for vendor libraries in composer.json');
 
         $this->addArgument(
             'libs-dir',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that bundle-autoload command reads from the extension's root composer.json file.
  * Enhanced backup-sources option documentation with behavior details.
  * Updated schema definition to specify root composer.json file usage.

* **Chores**
  * Adjusted file tracking configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->