### PR TITLE
[FEATURE] Provide `extract-dependencies` command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -174,6 +174,58 @@ Fail execution if dependency extraction finishes with problems.
 > If omitted, the `autoload.dependencyExtraction.failOnProblems` option from the config file
 > will be used instead.
 
+## [`extract-dependencies`](../src/Command/ExtractDependenciesCommand.php)
+
+Extracts dependencies from root `composer.json` file and optionally prints or writes
+the corresponding `composer.json` file. This can be useful for debugging, especially
+when testing the behavior of bundlers in case automatic dependency extraction is enabled.
+
+```bash
+composer extract-dependencies \
+    [<libs-dir>] \
+    [-c|--config CONFIG] \
+    [-f|--[no-]fail] \
+    [-p|--print-file-contents] \
+    [-w|--dump-to-file]
+```
+
+Pass the following options to the console command:
+
+### `<libs-dir>`
+
+Absolute or relative path to `composer.json` where vendor libraries are managed.
+This is usually a separate `composer.json` file which requires and prepares all
+vendor libraries for use in classic mode.
+
+> [!NOTE]
+> If omitted, the `pathToVendorLibraries` option from the config file will be
+> used instead. If no config file is available, the command will fail.
+
+### `-c|--config`
+
+Path to [config file](config-file), defaults to auto-detection in current
+working directory.
+
+### `-f|--[no-]fail`
+
+Fail execution if dependency extraction finishes with problems.
+
+> [!NOTE]
+> If omitted, the `autoload.dependencyExtraction.failOnProblems` option from the config file
+> will be used instead.
+
+### `p|--print-file-contents`
+
+Display the file contents of a `composer.json` file which contains extracted
+dependencies as well as excluded libraries. This can be useful for debugging,
+because it does not write any files to disk.
+
+### `-w|--dump-to-file`
+
+Dump extracted dependencies to a `composer.json` file in the path to vendor
+libraries. Use this option to prepare (and optionally commit) a `composer.json`
+file with the extracted dependencies, useable for further bundling.
+
 ## [`validate-bundler-config`](../src/Command/ValidateBundlerConfigCommand.php)
 
 Checks if the given bundler configuration is valid.

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -1,7 +1,7 @@
 # Automatic dependency extraction
 
 When vendor libraries are being bundled for usage in classic mode installations,
-there are several ways to define those dependencies:
+there are two ways to define those dependencies:
 
 1. **Manually** using a dedicated, separate `composer.json` file, located at the
    configured path to vendor libraries.
@@ -57,7 +57,16 @@ You can also use the command option `--extract` for all supported commands, e.g.
 > Read more about available [configuration options](schema.md#dependency-extraction)
 > and [command options](cli.md).
 
-### Standalone
+### Standalone (CLI)
+
+The console command [`composer extract-dependencies`](cli.md#extract-dependencies) can be
+used to extract dependencies from the root `composer.json` file, without executing any
+bundlers. This is especially useful for debugging purposes.
+
+Please refer to the [CLI command documentation](cli.md#extract-dependencies) for more
+information about how to use this command.
+
+### Standalone (PHP API)
 
 Check out the example in [PHP API](api.md#extract-dependencies-from-composerjson) to learn
 how to use the provided PHP API for automatic dependency extraction.

--- a/rector.php
+++ b/rector.php
@@ -40,6 +40,7 @@ return static function (RectorConfig $rectorConfig): void {
         ->skip(NullToStrictStringFuncCallArgRector::class, [
             __DIR__.'/src/Command/BundleAutoloadCommand.php',
             __DIR__.'/src/Command/BundleDependenciesCommand.php',
+            __DIR__.'/src/Command/ExtractDependenciesCommand.php',
         ])
         ->apply()
         ->cacheDirectory('.build/cache/rector')

--- a/src/Bundler/CanExtractDependencies.php
+++ b/src/Bundler/CanExtractDependencies.php
@@ -74,7 +74,7 @@ trait CanExtractDependencies
         );
 
         $this->taskRunner->run(
-            '✍️ Creating temporary <comment>composer.json</comment> file for extracted vendor libraries',
+            '✍️ Creating <comment>composer.json</comment> file for extracted vendor libraries',
             function () use ($dependencySet, $rootComposer) {
                 $composerJson = Filesystem\Path::join($this->librariesPath, 'composer.json');
                 $dependencySet->dumpToFile($composerJson, $rootComposer);

--- a/src/Command/ExtractDependenciesCommand.php
+++ b/src/Command/ExtractDependenciesCommand.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-vendor-bundler".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3VendorBundler\Command;
+
+use Composer\Composer;
+use Composer\Factory;
+use Composer\IO;
+use EliasHaeussler\TaskRunner;
+use EliasHaeussler\Typo3VendorBundler\Resource;
+use Symfony\Component\Console;
+use Symfony\Component\Filesystem;
+use Throwable;
+
+use function file_get_contents;
+use function sprintf;
+
+/**
+ * ExtractDependenciesCommand.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ExtractDependenciesCommand extends AbstractConfigurationAwareCommand
+{
+    private readonly Filesystem\Filesystem $filesystem;
+    private TaskRunner\TaskRunner $taskRunner;
+
+    public function __construct()
+    {
+        parent::__construct('extract-dependencies');
+
+        $this->filesystem = new Filesystem\Filesystem();
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setAliases(['extract']);
+        $this->setDescription('Extract vendor libraries to bundle from composer.json');
+
+        $this->addArgument(
+            'libs-dir',
+            Console\Input\InputArgument::OPTIONAL,
+            'Path to vendor libraries (either absolute or relative to working directory)',
+        );
+
+        $this->addOption(
+            'fail',
+            'f',
+            Console\Input\InputOption::VALUE_NONE | Console\Input\InputOption::VALUE_NEGATABLE,
+            'Fail execution if dependency extraction finishes with problems',
+        );
+        $this->addOption(
+            'print-file-contents',
+            'p',
+            Console\Input\InputOption::VALUE_NONE,
+            'Print contents of composer.json file instead of dumping it to a file',
+        );
+        $this->addOption(
+            'dump-to-file',
+            'w',
+            Console\Input\InputOption::VALUE_NONE,
+            'Dump extracted dependencies to target composer.json file',
+        );
+    }
+
+    protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+
+        $this->taskRunner = new TaskRunner\TaskRunner($this->io);
+    }
+
+    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
+    {
+        $configFile = $input->getOption('config');
+        $config = $this->readConfigFile($configFile, (string) getcwd());
+
+        // Exit if config cannot be read
+        if (null === $config) {
+            return self::INVALID;
+        }
+
+        $libsDir = $input->getArgument('libs-dir') ?? $config->pathToVendorLibraries();
+        $fail = $input->getOption('fail') ?? $config->dependencyExtraction()->failOnProblems() ?? true;
+        $print = $input->getOption('print-file-contents');
+        $dump = $input->getOption('dump-to-file');
+
+        // Exit if libs directory is invalid
+        if ($dump && '' === trim($libsDir)) {
+            $this->io->error('Please provide a valid path to vendor libraries.');
+
+            return self::INVALID;
+        }
+
+        $rootPath = (string) $config->rootPath();
+        $problems = [];
+
+        try {
+            $composer = Factory::create(new IO\NullIO(), Filesystem\Path::join($rootPath, 'composer.json'));
+        } catch (Throwable) {
+            $this->io->error('Could not initialize a Composer instance for the root package.');
+
+            return self::FAILURE;
+        }
+
+        // Extract dependencies using dependency extractor component
+        $dependencySet = $this->extractDependencies($composer, $dump, $print, $problems);
+
+        // List extraction problems
+        if ([] !== $problems) {
+            if ($fail) {
+                $this->io->error('Failed to extract some dependencies from composer.json file.');
+            } else {
+                $this->io->warning('Dependency extraction finished with problems.');
+            }
+
+            $this->io->listing($problems);
+
+            // Fail execution if configured to do so
+            if ($fail) {
+                return self::FAILURE;
+            }
+        }
+
+        // Fail if no vendor libraries were found
+        if ([] === $dependencySet->requiredPackages) {
+            $this->io->warning('No vendor libraries found in composer.json file.');
+
+            return self::FAILURE;
+        }
+
+        // Build and print composer.json from extracted dependencies
+        if ($print) {
+            $this->printFileContents($dependencySet, $composer);
+        }
+
+        // Dump extracted dependencies to composer.json file
+        if ($dump) {
+            $this->dumpToFile($dependencySet, $composer, $libsDir, $rootPath);
+
+            return self::SUCCESS;
+        }
+
+        $this->io->success('Successfully extracted dependencies from composer.json file.');
+        $this->io->writeln(
+            '💡 Run this command again with <comment>--dump-to-file</comment> or '.
+            '<comment>--print-file-contents</comment> to persist extracted dependencies.',
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $problems
+     */
+    private function extractDependencies(Composer $composer, bool $dump, bool $print, array &$problems = []): Resource\DependencySet
+    {
+        return $this->taskRunner->run(
+            '🔎 Extracting dependencies from root package',
+            function (TaskRunner\RunnerContext $context) use ($composer, $dump, $print, &$problems) {
+                $extractor = new Resource\DependencyExtractor();
+                $dependencySet = $extractor->extract($composer);
+                $problems = $dependencySet->problems();
+                $verbosity = !$dump && !$print ? Console\Output\OutputInterface::VERBOSITY_NORMAL : Console\Output\OutputInterface::VERBOSITY_VERBOSE;
+
+                // Display requirements (only on -v mode or if neither print nor dump are requested)
+                foreach ($dependencySet->requirements() as $packageName => $packageVersion) {
+                    $context->output->writeln(
+                        sprintf(
+                            '✅ Extracted <comment>%s</comment> (version: <comment>%s</comment>)',
+                            $packageName,
+                            $packageVersion,
+                        ),
+                        $verbosity,
+                    );
+                }
+
+                // Display exclusions (only on -vv mode)
+                foreach ($dependencySet->exclusions() as $packageName => $packageVersion) {
+                    $context->output->writeln(
+                        sprintf('⛔️ Excluded <comment>%s</comment> (all versions)', $packageName),
+                        Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+                    );
+                }
+
+                // Fail task if extraction problems occured
+                if ([] !== $problems) {
+                    $context->successful = false;
+                }
+
+                return $dependencySet;
+            },
+        );
+    }
+
+    private function printFileContents(Resource\DependencySet $dependencySet, Composer $composer): void
+    {
+        $this->taskRunner->run(
+            '✍️ Building <comment>composer.json</comment> file contents',
+            function (TaskRunner\RunnerContext $context) use ($dependencySet, $composer) {
+                $filename = $this->filesystem->tempnam(sys_get_temp_dir(), 'typo3-vendor-bundler-', '.json');
+                $this->filesystem->dumpFile($filename, '{}');
+
+                try {
+                    $dependencySet->dumpToFile($filename, $composer);
+                    $fileContents = file_get_contents($filename);
+
+                    if (false === $fileContents) {
+                        $context->successful = false;
+                    } else {
+                        $context->output->write($fileContents);
+                    }
+                } finally {
+                    unlink($filename);
+                }
+            },
+        );
+    }
+
+    private function dumpToFile(
+        Resource\DependencySet $dependencySet,
+        Composer $composer,
+        string $libsDir,
+        string $rootPath,
+    ): void {
+        $librariesPath = Filesystem\Path::makeAbsolute($libsDir, $rootPath);
+        $filename = Filesystem\Path::join($librariesPath, 'composer.json');
+
+        $this->taskRunner->run(
+            '✍️ Creating <comment>composer.json</comment> file for extracted vendor libraries',
+            static fn () => $dependencySet->dumpToFile($filename, $composer),
+        );
+
+        $this->io->success(
+            sprintf(
+                'Successfully extracted and dumped dependencies to "%s".',
+                Filesystem\Path::makeRelative($filename, $rootPath),
+            ),
+        );
+    }
+}

--- a/src/Typo3VendorBundlerPlugin.php
+++ b/src/Typo3VendorBundlerPlugin.php
@@ -56,6 +56,7 @@ final readonly class Typo3VendorBundlerPlugin implements Plugin\PluginInterface,
             ]),
             $bundleAutoloadCommand,
             $bundleDependenciesCommand,
+            new Command\ExtractDependenciesCommand(),
             new Command\ValidateBundlerConfigCommand(),
         ];
     }

--- a/tests/build/console-application.php
+++ b/tests/build/console-application.php
@@ -29,6 +29,7 @@ $application->addCommands([
     new Command\BundleCommand(),
     new Command\BundleAutoloadCommand(),
     new Command\BundleDependenciesCommand(),
+    new Command\ExtractDependenciesCommand(),
     new Command\ValidateBundlerConfigCommand(),
 ]);
 

--- a/tests/src/Bundler/AutoloadBundlerTest.php
+++ b/tests/src/Bundler/AutoloadBundlerTest.php
@@ -82,7 +82,7 @@ final class AutoloadBundlerTest extends Framework\TestCase
         $output = $this->output->fetch();
 
         self::assertStringContainsString('🔎 Extracting dependencies from root package... Done', $output);
-        self::assertStringContainsString('✍️ Creating temporary composer.json file for extracted vendor libraries... Done', $output);
+        self::assertStringContainsString('✍️ Creating composer.json file for extracted vendor libraries... Done', $output);
 
         $actual = $this->parseComposerJson($librariesPath.'/composer.json');
         $requires = $actual->getRequires();

--- a/tests/src/Bundler/DependencyBundlerTest.php
+++ b/tests/src/Bundler/DependencyBundlerTest.php
@@ -78,7 +78,7 @@ final class DependencyBundlerTest extends Framework\TestCase
         $output = $this->output->fetch();
 
         self::assertStringContainsString('🔎 Extracting dependencies from root package... Done', $output);
-        self::assertStringContainsString('✍️ Creating temporary composer.json file for extracted vendor libraries... Done', $output);
+        self::assertStringContainsString('✍️ Creating composer.json file for extracted vendor libraries... Done', $output);
 
         $actual = $this->parseComposerJson($librariesPath.'/composer.json');
         $requires = $actual->getRequires();

--- a/tests/src/Command/ExtractDependenciesCommandTest.php
+++ b/tests/src/Command/ExtractDependenciesCommandTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-vendor-bundler".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3VendorBundler\Tests\Command;
+
+use Composer\Console\Application;
+use EliasHaeussler\Typo3VendorBundler as Src;
+use Generator;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+use Symfony\Component\Filesystem;
+
+use function dirname;
+
+/**
+ * ExtractDependenciesCommandTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Command\ExtractDependenciesCommand::class)]
+final class ExtractDependenciesCommandTest extends Framework\TestCase
+{
+    private Console\Tester\CommandTester $commandTester;
+    private Filesystem\Filesystem $filesystem;
+
+    public function setUp(): void
+    {
+        $application = new Application();
+        $command = new Src\Command\ExtractDependenciesCommand();
+        $command->setApplication($application);
+
+        $this->commandTester = new Console\Tester\CommandTester($command);
+        $this->filesystem = new Filesystem\Filesystem();
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeFailsIfConfigFileCannotBeRead(): void
+    {
+        $this->commandTester->execute([
+            '--config' => 'foo',
+        ]);
+
+        self::assertSame(Console\Command\Command::INVALID, $this->commandTester->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '/\[ERROR] File ".+\/foo" does not exist\./',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeFailsIfPathToVendorLibrariesIsInvalidAndDumpOptionIsSet(): void
+    {
+        $this->commandTester->execute([
+            'libs-dir' => '',
+            '--dump-to-file' => true,
+        ]);
+
+        self::assertSame(Console\Command\Command::INVALID, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'Please provide a valid path to vendor libraries',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeFailsIfRootComposerInstanceCannotBeCreated(): void
+    {
+        $this->commandTester->execute([
+            '--config' => dirname(__DIR__).'/Fixtures/Extensions/invalid-composer-file/typo3-vendor-bundler.yaml',
+        ]);
+
+        self::assertSame(Console\Command\Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'Could not initialize a Composer instance for the root package.',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    /**
+     * @return Generator<string, array{array<string, bool>, Console\Output\OutputInterface::VERBOSITY_*, bool}>
+     */
+    public static function executeDisplaysExtractedDependenciesDataProvider(): Generator
+    {
+        yield 'no options, verbosity normal' => [
+            [],
+            Console\Output\OutputInterface::VERBOSITY_NORMAL,
+            true,
+        ];
+        yield 'dump option, verbosity normal' => [
+            ['--dump-to-file' => true],
+            Console\Output\OutputInterface::VERBOSITY_NORMAL,
+            false,
+        ];
+        yield 'dump option, verbosity verbose' => [
+            ['--dump-to-file' => true],
+            Console\Output\OutputInterface::VERBOSITY_VERBOSE,
+            true,
+        ];
+        yield 'print option, verbosity normal' => [
+            ['--print-file-contents' => true],
+            Console\Output\OutputInterface::VERBOSITY_NORMAL,
+            false,
+        ];
+        yield 'print option, verbosity verbose' => [
+            ['--print-file-contents' => true],
+            Console\Output\OutputInterface::VERBOSITY_VERBOSE,
+            true,
+        ];
+    }
+
+    /**
+     * @param array<string, bool>                         $input
+     * @param Console\Output\OutputInterface::VERBOSITY_* $verbosity
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('executeDisplaysExtractedDependenciesDataProvider')]
+    public function executeDisplaysExtractedDependencies(array $input, int $verbosity, bool $expected): void
+    {
+        $input['--config'] = dirname(__DIR__).'/Fixtures/Extensions/valid-no-libs/typo3-vendor-bundler.yaml';
+
+        $this->commandTester->execute($input, ['verbosity' => $verbosity]);
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('🔎 Extracting dependencies from root package... Done', $output);
+        self::assertStringNotContainsString('Excluded psr/http-message', $output);
+
+        if ($expected) {
+            self::assertStringContainsString('Extracted eliashaeussler/sse', $output);
+        } else {
+            self::assertStringNotContainsString('Extracted eliashaeussler/sse', $output);
+        }
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeDisplaysExcludedDependenciesOnVeryVerboseOutput(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--config' => dirname(__DIR__).'/Fixtures/Extensions/valid-no-libs/typo3-vendor-bundler.yaml',
+            ],
+            [
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('🔎 Extracting dependencies from root package... Done', $output);
+        self::assertStringContainsString('Excluded psr/http-message', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeFailsOnExtractionProblems(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--config' => dirname(__DIR__).'/Fixtures/Extensions/invalid-libs-constraint/typo3-vendor-bundler.yaml',
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::FAILURE, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('🔎 Extracting dependencies from root package... Failed', $output);
+        self::assertStringContainsString(
+            'Could not find a matching version for the Composer package "eliashaeussler/cache-warmup".',
+            $output,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeDoesNotFailOnExtractionProblemsIfNoFailOptionIsGiven(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--config' => dirname(__DIR__).'/Fixtures/Extensions/invalid-libs-constraint/typo3-vendor-bundler.yaml',
+                '--fail' => false,
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('🔎 Extracting dependencies from root package... Failed', $output);
+        self::assertStringContainsString('Dependency extraction finished with problems.', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeFailsIfNoVendorLibrariesWereFoundInRootComposerJson(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--config' => dirname(__DIR__).'/Fixtures/Extensions/invalid-libs/typo3-vendor-bundler.yaml',
+                '--fail' => false,
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringContainsString(
+            'No vendor libraries found in composer.json file.',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeDisplaysComposerJsonFileContentsIfPrintOptionIsGiven(): void
+    {
+        $this->commandTester->execute(
+            [
+                '--config' => dirname(__DIR__).'/Fixtures/Extensions/valid-no-libs/typo3-vendor-bundler.yaml',
+                '--print-file-contents' => true,
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('✍️ Building composer.json file contents... Done', $output);
+        self::assertStringContainsString('"eliashaeussler/sse": "', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeWritesComposerJsonToFileIfDumpOptionIsGiven(): void
+    {
+        $rootPath = dirname(__DIR__).'/Fixtures/Extensions/valid-no-libs';
+
+        $this->filesystem->remove($rootPath.'/libs');
+
+        $this->commandTester->execute(
+            [
+                '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
+                '--dump-to-file' => true,
+            ],
+        );
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('✍️ Creating composer.json file for extracted vendor libraries... Done', $output);
+        self::assertStringContainsString('Successfully extracted and dumped dependencies', $output);
+        self::assertFileExists($rootPath.'/libs/composer.json');
+    }
+}

--- a/tests/src/Fixtures/Extensions/invalid-composer-file/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/invalid-composer-file/typo3-vendor-bundler.yaml
@@ -1,0 +1,1 @@
+pathToVendorLibraries: 'libs'

--- a/tests/src/Fixtures/Extensions/invalid-libs-constraint/composer.json
+++ b/tests/src/Fixtures/Extensions/invalid-libs-constraint/composer.json
@@ -1,6 +1,7 @@
 {
 	"require": {
 		"eliashaeussler/cache-warmup": "~0.7.0",
+		"eliashaeussler/sse": "*",
 		"typo3/cms-core": "*"
 	}
 }

--- a/tests/src/Fixtures/Extensions/invalid-libs-constraint/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/invalid-libs-constraint/typo3-vendor-bundler.yaml
@@ -1,0 +1,1 @@
+pathToVendorLibraries: 'libs'

--- a/tests/src/Fixtures/Extensions/invalid-libs/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/invalid-libs/typo3-vendor-bundler.yaml
@@ -1,0 +1,1 @@
+pathToVendorLibraries: 'libs'

--- a/tests/src/Fixtures/Extensions/valid-no-libs/typo3-vendor-bundler.yaml
+++ b/tests/src/Fixtures/Extensions/valid-no-libs/typo3-vendor-bundler.yaml
@@ -1,0 +1,1 @@
+pathToVendorLibraries: 'libs'

--- a/tests/src/Resource/DependencyExtractorTest.php
+++ b/tests/src/Resource/DependencyExtractorTest.php
@@ -84,7 +84,8 @@ final class DependencyExtractorTest extends Framework\TestCase
 
         $actual = $this->subject->extract($this->createComposerInstance('invalid-libs-constraint'));
 
-        self::assertSame([], $actual->requiredPackages);
+        self::assertArrayHasKey('eliashaeussler/sse', $actual->requiredPackages);
+        self::assertArrayNotHasKey('eliashaeussler/cache-warmup', $actual->requiredPackages);
         self::assertSame($expected, $actual->extractionProblems);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to extract vendor dependencies and produce a standalone composer.json (options to dump to file, print contents, and fail-on-problems).

* **Style**
  * Clarified on-screen status message during composer.json creation (removed "temporary" wording).

* **Bug Fixes**
  * Improved robustness when writing/initializing the extracted composer.json and surface invalid-file errors.

* **Documentation**
  * Added CLI and extraction usage docs and examples.

* **Tests**
  * Added comprehensive tests for the new command and updated expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->