### PR TITLE
[FEATURE] Allow disabling bundlers by configuration

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,11 +8,16 @@ Executes all available bundlers in a single run.
 composer bundle [-c|--config CONFIG]
 ```
 
+> [!TIP]
+> By default, all available bundlers are executed. This can be configured
+> by disabling individual bundlers in the [config file](config-file.md).
+> Read more in the [schema documentation](schema.md).
+
 Pass the following options to the console command:
 
 ### `-c|--config`
 
-Path to [config file](config-file), defaults to auto-detection in current
+Path to [config file](config-file.md), defaults to auto-detection in current
 working directory.
 
 ## [`bundle-autoload`](../src/Command/BundleAutoloadCommand.php)
@@ -45,7 +50,7 @@ vendor libraries for use in classic mode.
 
 ### `-c|--config`
 
-Path to [config file](config-file), defaults to auto-detection in current
+Path to [config file](config-file.md), defaults to auto-detection in current
 working directory.
 
 ### `t|--target-file`
@@ -123,7 +128,7 @@ vendor libraries for use in classic mode.
 
 ### `-c|--config`
 
-Path to [config file](config-file), defaults to auto-detection in current
+Path to [config file](config-file.md), defaults to auto-detection in current
 working directory.
 
 ### `f|--sbom-file`
@@ -203,7 +208,7 @@ vendor libraries for use in classic mode.
 
 ### `-c|--config`
 
-Path to [config file](config-file), defaults to auto-detection in current
+Path to [config file](config-file.md), defaults to auto-detection in current
 working directory.
 
 ### `-f|--[no-]fail`
@@ -238,5 +243,5 @@ Pass the following options to the console command:
 
 ### `-c|--config`
 
-Path to [config file](config-file), defaults to auto-detection in current
+Path to [config file](config-file.md), defaults to auto-detection in current
 working directory.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,6 +4,7 @@ The config file must follow a given schema:
 
 ```yaml
 autoload:
+  enabled: true
   target:
     file: 'composer.json'
     overwrite: false
@@ -12,6 +13,7 @@ autoload:
     - 'vendor/composer/InstalledVersions.php'
 
 dependencies:
+  enabled: true
   sbom:
     file: 'sbom.json'
     version: '1.7'
@@ -47,13 +49,14 @@ rootPath: ../
 > [!TIP]
 > Read more about [autoload bundling](bundlers/autoload.md).
 
-| Property                       | Type    | Default value   | Description                                                        |
-|--------------------------------|---------|-----------------|--------------------------------------------------------------------|
-| `autoload.target`              | Object  | –               | Set of configuration options related to the bundle target.         |
-| `autoload.target.file`         | String  | `composer.json` | File where to bundle autoload configuration.                       |
-| `autoload.target.overwrite`    | Boolean | `false`         | Define whether to overwrite the target file, if it already exists. |
-| `autoload.backupSources`       | Boolean | `false`         | Define whether to backup source files.                             |
-| `autoload.excludeFromClassMap` | Array   | –               | List of files to exclude from vendor libraries class map.          |
+| Property                       | Type    | Default value   | Description                                                                                    |
+|--------------------------------|---------|-----------------|------------------------------------------------------------------------------------------------|
+| `autoload.enabled`             | Boolean | `true`          | Define whether autoload bundling is enabled when executing [`composer bundle`](cli.md#bundle). |
+| `autoload.target`              | Object  | –               | Set of configuration options related to the bundle target.                                     |
+| `autoload.target.file`         | String  | `composer.json` | File where to bundle autoload configuration.                                                   |
+| `autoload.target.overwrite`    | Boolean | `false`         | Define whether to overwrite the target file, if it already exists.                             |
+| `autoload.backupSources`       | Boolean | `false`         | Define whether to backup source files.                                                         |
+| `autoload.excludeFromClassMap` | Array   | –               | List of files to exclude from vendor libraries class map.                                      |
 
 ## Dependencies
 
@@ -62,6 +65,7 @@ rootPath: ../
 
 | Property                       | Type    | Default value | Description                                                                                                                         |
 |--------------------------------|---------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `dependencies.enabled`         | Boolean | `true`        | Define whether dependency bundling is enabled when executing [`composer bundle`](cli.md#bundle).                                    |
 | `dependencies.sbom`            | Object  | –             | Set of configuration options used to define SBOM file generation.                                                                   |
 | `dependencies.sbom.file`       | String  | `sbom.json`   | File where to write the serialized SBOM. Can be a JSON or XML file. Relative paths are resolved based on the vendor libraries path. |
 | `dependencies.sbom.version`    | String  | `1.7`         | CycloneDX BOM version to use.                                                                                                       |

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -29,6 +29,12 @@
 			"type": "object",
 			"title": "Set of options used to bundle autoload configuration",
 			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"title": "Define whether autoload bundling is enabled",
+					"description": "When enabled, the autoload bundler will be included when executing `composer bundle`.",
+					"default": true
+				},
 				"target": {
 					"$ref": "#/definitions/autoloadTarget"
 				},
@@ -73,6 +79,12 @@
 			"type": "object",
 			"title": "Set of options used to bundle dependency information",
 			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"title": "Define whether dependency bundling is enabled",
+					"description": "When enabled, the dependency bundler will be included when executing `composer bundle`.",
+					"default": true
+				},
 				"sbom": {
 					"$ref": "#/definitions/sbom"
 				}

--- a/src/Config/AutoloadConfig.php
+++ b/src/Config/AutoloadConfig.php
@@ -35,10 +35,16 @@ final readonly class AutoloadConfig
      * @param list<non-empty-string> $excludeFromClassMap
      */
     public function __construct(
+        private bool $enabled = true,
         private AutoloadTarget $target = new AutoloadTarget(),
         private ?bool $backupSources = null,
         private array $excludeFromClassMap = [],
     ) {}
+
+    public function enabled(): bool
+    {
+        return $this->enabled;
+    }
 
     public function target(): AutoloadTarget
     {

--- a/src/Config/DependenciesConfig.php
+++ b/src/Config/DependenciesConfig.php
@@ -32,8 +32,14 @@ namespace EliasHaeussler\Typo3VendorBundler\Config;
 final readonly class DependenciesConfig
 {
     public function __construct(
+        private bool $enabled = true,
         private Sbom $sbom = new Sbom(),
     ) {}
+
+    public function enabled(): bool
+    {
+        return $this->enabled;
+    }
 
     public function sbom(): Sbom
     {

--- a/tests/src/Fixtures/ConfigFiles/valid-config-autoload-disabled.yaml
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-autoload-disabled.yaml
@@ -1,0 +1,8 @@
+pathToVendorLibraries: libs
+rootPath: ../Extensions/valid
+autoload:
+  enabled: false
+dependencies:
+  sbom:
+    file: sbom_generated.json
+    overwrite: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autoload and dependency bundling can now be independently enabled or disabled via configuration, providing more granular control over bundle operations.

* **Documentation**
  * Updated configuration schema and command-line documentation with clearer descriptions of bundling options and improved cross-references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->