### PR TITLE
[TASK] Rename `--sbom-file` shortcut from `-b` to `-s`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ composer bundle-dependencies \
     [<libs-dir>] \
     [-c|--config CONFIG] \
     [-f|--sbom-file SBOM-FILE] \
-    [-b|--sbom-version SBOM-VERSION] \
+    [-s|--sbom-version SBOM-VERSION] \
     [--[no-]dev] \
     [-o|--[no-]overwrite] \
     [-x|--[no-]extract] \
@@ -139,7 +139,7 @@ or `sbom.xml`.
 > [!NOTE]
 > If omitted, the `dependencies.sbom.file` option from the config file will be used instead.
 
-### `-b|--sbom-version`
+### `-s|--sbom-version`
 
 The CycloneDX BOM version to use. Must be an a supported version number, which
 is available in the provided [`Version` enum](https://github.com/CycloneDX/cyclonedx-php-library/blob/master/src/Core/Spec/Version.php).

--- a/src/Command/BundleDependenciesCommand.php
+++ b/src/Command/BundleDependenciesCommand.php
@@ -66,7 +66,7 @@ final class BundleDependenciesCommand extends AbstractConfigurationAwareCommand
         );
         $this->addOption(
             'sbom-version',
-            'b',
+            's',
             Console\Input\InputOption::VALUE_REQUIRED,
             sprintf(
                 'Version to use when dumping the generated SBOM (defaults to "%s")',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the short flag for the `sbom-version` option in the bundle-dependencies command from `-b` to `-s`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->