### PR TITLE
[FEATURE] Dump bundler metadata to root `composer.json` file

### DIFF
--- a/docs/bundlers/autoload.md
+++ b/docs/bundlers/autoload.md
@@ -21,6 +21,21 @@ maps, PSR-4 namespaces and autoload files are loaded, they are merged and dumped
 the root `composer.json` file. This makes all autoloaded classes and files available
 to TYPO3's autoloader in classic mode.
 
+The configured path to vendor libraries will be written as `extra` property to the
+configured root `composer.json` file like follows:
+
+```json
+{
+    "extra": {
+        "typo3/cms": {
+            "vendor-libraries": {
+                "root-path": "Resources/Private/Libs"
+            }
+        }
+    }
+}
+```
+
 ## Configuration options
 
 The bundler's behavior can be controlled in various ways:
@@ -47,6 +62,11 @@ Given the following root `composer.json` file:
     "autoload": {
         "psr-4": {
             "EliasHaeussler\\TestExtension\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_extension"
         }
     }
 }
@@ -76,6 +96,14 @@ into the `autoload` section of the root `composer.json` file:
             "EliasHaeussler\\CacheWarmup\\": ["Resources/Private/Libs/vendor/eliashaeussler/cache-warmup/src"],
             "EliasHaeussler\\SSE\\": ["Resources/Private/Libs/vendor/eliashaeussler/sse/src"],
             // ...
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_extension",
+            "vendor-libraries": {
+                "root-path": "Resources/Private/Libs"
+            }
         }
     }
 }

--- a/docs/bundlers/dependencies.md
+++ b/docs/bundlers/dependencies.md
@@ -20,6 +20,22 @@ file in CycloneDX format. The SBOM file is dumped in JSON or XML format and is b
 default located next to the original `composer.json` file within the path to vendor
 libraries, e.g. `Resources/Private/Libs/sbom.json`.
 
+The configured path to vendor libraries and the relative path to the generated SBOM
+file will be written as `extra` properties to the root `composer.json` file like follows:
+
+```json
+{
+    "extra": {
+        "typo3/cms": {
+            "vendor-libraries": {
+                "root-path": "Resources/Private/Libs",
+                "sbom-file": "Resources/Private/Libs/sbom.json"
+            }
+        }
+    }
+}
+```
+
 ## Configuration options
 
 The bundler's behavior can be controlled in various ways:

--- a/src/Bundler/AutoloadBundler.php
+++ b/src/Bundler/AutoloadBundler.php
@@ -52,6 +52,7 @@ use function sprintf;
 final readonly class AutoloadBundler implements Bundler
 {
     use CanExtractDependencies;
+    use CanModifyExtraSection;
 
     private Filesystem\Filesystem $filesystem;
     private TaskRunner\TaskRunner $taskRunner;
@@ -124,6 +125,14 @@ final readonly class AutoloadBundler implements Bundler
                 $configSource->addProperty('autoload', (object) $autoload->toArray(true));
             },
         );
+
+        // Write metadata to composer.json
+        if (!$this->extraSectionIsPrepared()) {
+            $this->taskRunner->run(
+                '✍️ Writing dependency metadata to <comment>composer.json</comment> file',
+                fn () => $this->prepareExtraSection(),
+            );
+        }
 
         return $autoload;
     }

--- a/src/Bundler/CanModifyExtraSection.php
+++ b/src/Bundler/CanModifyExtraSection.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/typo3-vendor-bundler".
+ *
+ * Copyright (C) 2025-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3VendorBundler\Bundler;
+
+use Symfony\Component\Filesystem;
+
+/**
+ * CanModifyExtraSection.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+trait CanModifyExtraSection
+{
+    private function modifyExtraSection(string $key, string $value): void
+    {
+        $this->rootComposer->writeExtra('typo3/cms.vendor-libraries.'.$key, $value);
+    }
+
+    private function extraSectionNeedsUpdate(string $key, string $value): bool
+    {
+        $configuredValue = $this->rootComposer->readExtra('typo3/cms.vendor-libraries.'.$key);
+
+        return $configuredValue !== $value;
+    }
+
+    private function prepareExtraSection(): void
+    {
+        $this->modifyExtraSection(
+            'root-path',
+            Filesystem\Path::makeRelative($this->librariesPath, $this->rootPath),
+        );
+    }
+
+    private function extraSectionIsPrepared(): bool
+    {
+        return !$this->extraSectionNeedsUpdate(
+            'root-path',
+            Filesystem\Path::makeRelative($this->librariesPath, $this->rootPath),
+        );
+    }
+}

--- a/tests/src/Bundler/AutoloadBundlerTest.php
+++ b/tests/src/Bundler/AutoloadBundlerTest.php
@@ -243,6 +243,34 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
         }
     }
 
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\WithoutErrorHandler]
+    public function bundleWritesMetadataToRootComposerJson(): void
+    {
+        $composerJson = $this->rootPath.'/composer.json';
+
+        try {
+            $this->subject->bundle();
+        } finally {
+            $output = $this->output->fetch();
+
+            self::assertStringContainsString('📦 Installing vendor libraries... Done', $output);
+            self::assertStringContainsString('🪄 Parsing autoloads from composer.json files... Done', $output);
+            self::assertStringContainsString('✍️ Writing dependency metadata to composer.json file... Done', $output);
+
+            $expected = [
+                'extension-key' => 'test',
+                'vendor-libraries' => [
+                    'root-path' => 'libs',
+                ],
+            ];
+
+            $actual = $this->parseComposerJson($composerJson);
+
+            self::assertSame($expected, $actual->getExtra()['typo3/cms'] ?? null);
+        }
+    }
+
     private function createSubject(string $rootPath, string $librariesPath = 'libs'): Src\Bundler\AutoloadBundler
     {
         return new Src\Bundler\AutoloadBundler($rootPath, $librariesPath, $this->output);

--- a/tests/src/Fixtures/Extensions/valid/composer.json
+++ b/tests/src/Fixtures/Extensions/valid/composer.json
@@ -9,5 +9,10 @@
 		"files": [
 			"foo.php"
 		]
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "test"
+		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundling now automatically records vendor library root path and SBOM file path into the root composer.json extra.typo3/cms section (includes extension key and relative paths).

* **Documentation**
  * Added examples and JSON snippets demonstrating how vendor-root and SBOM entries appear under extra.typo3/cms.

* **Tests**
  * Added tests confirming bundling writes the expected extra metadata into composer.json.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->