### PR TITLE
[FEATURE] Provide backup option for dependency bundler

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,6 +90,7 @@ composer bundle-dependencies \
     [-f|--sbom-file SBOM-FILE] \
     [-s|--sbom-version SBOM-VERSION] \
     [--[no-]dev] \
+    [-b|--[no-]backup-sources] \
     [-o|--[no-]overwrite] \
     [-x|--[no-]extract] \
     [--[no-]fail]
@@ -135,6 +136,15 @@ Define whether to include development dependencies in the generated SBOM.
 
 > [!NOTE]
 > If omitted, the `dependencies.sbom.includeDev` option from the config file will be used instead.
+
+### `-b|--[no-]backup-sources`
+
+Define whether to backup source files (normally the root `composer.json` file of the extension).
+When enabled, original contents of source files, which are to be modified, will be backed
+up in a separate file. If no contents would be modified, no backup files will be generated.
+
+> [!NOTE]
+> If omitted, the `dependencies.backupSources` option from the config file will be used instead.
 
 ### `-o|--[no-]overwrite`
 

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -40,6 +40,7 @@ return new Typo3VendorBundler\Config\Typo3VendorBundlerConfig(
         sbom: new Typo3VendorBundler\Config\Sbom(
             includeDev: false,
         ),
+        backupSources: true,
     ),
     dependencyExtraction: new Typo3VendorBundler\Config\DependencyExtractionConfig(
         enabled: true,

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -16,6 +16,7 @@ dependencies:
     version: '1.7'
     includeDev: false
     overwrite: true
+  backupSources: false
 
 dependencyExtraction:
   enabled: true
@@ -65,6 +66,7 @@ rootPath: ../
 | `dependencies.sbom.version`    | String  | `1.7`         | CycloneDX BOM version to use.                                                                                                       |
 | `dependencies.sbom.includeDev` | Boolean | `true`        | Define whether to include development dependencies in the serialized SBOM.                                                          |
 | `dependencies.sbom.overwrite`  | Boolean | `false`       | Define whether to overwrite the SBOM file, if it already exists.                                                                    |
+| `dependencies.backupSources`   | Boolean | `false`       | Define whether to backup source files.                                                                                              |
 
 ## Dependency extraction
 

--- a/res/typo3-vendor-bundler.schema.json
+++ b/res/typo3-vendor-bundler.schema.json
@@ -65,6 +65,12 @@
 				},
 				"sbom": {
 					"$ref": "#/definitions/sbom"
+				},
+				"backupSources": {
+					"type": "boolean",
+					"title": "Define whether to backup source files",
+					"description": "When enabled, original contents of source files, which are to be modified, will be backed up in a separate file",
+					"default": false
 				}
 			},
 			"additionalProperties": false

--- a/src/Bundler/DependencyBundler.php
+++ b/src/Bundler/DependencyBundler.php
@@ -80,6 +80,7 @@ final readonly class DependencyBundler implements Bundler
         bool $failOnExtractionProblems = true,
         bool $includeDevDependencies = true,
         bool $overwrite = false,
+        bool $backupSources = false,
     ): Entity\Dependencies {
         $format = Resource\BomFormat::fromFile($filename);
 
@@ -126,8 +127,20 @@ final readonly class DependencyBundler implements Bundler
         // Serialize generated SBOM
         $this->serializeBom($version, $bom, $format, $filename);
 
-        // Write metadata to composer.json
         if (!$this->extraSectionIsPrepared() || $this->extraSectionNeedsUpdate('sbom-file', $sbomFile)) {
+            // Create composer.json backup
+            if (true === $backupSources) {
+                $this->taskRunner->run(
+                    '🦖 Backing up source files',
+                    function () {
+                        $composerJson = $this->rootComposer->composer->getConfig()->getConfigSource()->getName();
+
+                        $this->filesystem->copy($composerJson, $composerJson.'.bak');
+                    },
+                );
+            }
+
+            // Write metadata to composer.json
             $this->taskRunner->run(
                 '✍️ Writing dependency metadata to <comment>composer.json</comment> file',
                 function () use ($sbomFile) {

--- a/src/Command/BundleDependenciesCommand.php
+++ b/src/Command/BundleDependenciesCommand.php
@@ -80,6 +80,12 @@ final class BundleDependenciesCommand extends AbstractConfigurationAwareCommand
             'Include development dependencies in the generated SBOM file',
         );
         $this->addOption(
+            'backup-sources',
+            'b',
+            Console\Input\InputOption::VALUE_NONE | Console\Input\InputOption::VALUE_NEGATABLE,
+            'Backup source files before they get overwritten',
+        );
+        $this->addOption(
             'overwrite',
             'o',
             Console\Input\InputOption::VALUE_NONE | Console\Input\InputOption::VALUE_NEGATABLE,
@@ -122,6 +128,7 @@ final class BundleDependenciesCommand extends AbstractConfigurationAwareCommand
         $sbomFile = $input->getOption('sbom-file') ?? $config->dependencies()->sbom()->file();
         $includeDev = $input->getOption('dev') ?? $config->dependencies()->sbom()->includeDev() ?? true;
         $overwrite = $input->getOption('overwrite') ?? $config->dependencies()->sbom()->overwrite() ?? false;
+        $backupSources = $input->getOption('backup-sources') ?? $config->dependencies()->backupSources() ?? false;
 
         // Read SBOM version
         if (($sbomVersion = $input->getOption('sbom-version')) !== null) {
@@ -147,7 +154,7 @@ final class BundleDependenciesCommand extends AbstractConfigurationAwareCommand
         $dependencyBundler = new Bundler\DependencyBundler($rootPath, $libsDir, $this->io);
 
         try {
-            $dependencies = $dependencyBundler->bundle($sbomFile, $sbomVersion, $extract, $fail, $includeDev, $overwrite);
+            $dependencies = $dependencyBundler->bundle($sbomFile, $sbomVersion, $extract, $fail, $includeDev, $overwrite, $backupSources);
         } catch (Exception\FileAlreadyExists $exception) {
             if (false === $input->getOption('overwrite')
                 || !$this->io->confirm('SBOM file already exists. Overwrite file?', false)
@@ -155,7 +162,7 @@ final class BundleDependenciesCommand extends AbstractConfigurationAwareCommand
                 throw $exception;
             }
 
-            $dependencies = $dependencyBundler->bundle($sbomFile, $sbomVersion, $extract, $fail, $includeDev, true);
+            $dependencies = $dependencyBundler->bundle($sbomFile, $sbomVersion, $extract, $fail, $includeDev, true, $backupSources);
         }
 
         $this->io->success(

--- a/src/Config/DependenciesConfig.php
+++ b/src/Config/DependenciesConfig.php
@@ -34,6 +34,7 @@ final readonly class DependenciesConfig
     public function __construct(
         private bool $enabled = true,
         private Sbom $sbom = new Sbom(),
+        private ?bool $backupSources = null,
     ) {}
 
     public function enabled(): bool
@@ -44,5 +45,10 @@ final readonly class DependenciesConfig
     public function sbom(): Sbom
     {
         return $this->sbom;
+    }
+
+    public function backupSources(): ?bool
+    {
+        return $this->backupSources;
     }
 }

--- a/tests/src/Command/BundleAutoloadCommandTest.php
+++ b/tests/src/Command/BundleAutoloadCommandTest.php
@@ -112,9 +112,10 @@ final class BundleAutoloadCommandTest extends Tests\ExtensionFixtureBasedTestCas
     }
 
     #[Framework\Attributes\Test]
+    #[Framework\Attributes\WithoutErrorHandler]
     public function executeUsesBackupSourcesOptionFromCommandOption(): void
     {
-        $rootPath = $this->createTemporaryDirectory();
+        $rootPath = $this->createTemporaryFixture();
 
         $this->commandTester->execute([
             '--config' => $rootPath.'/typo3-vendor-bundler.yaml',

--- a/tests/src/Command/BundleDependenciesCommandTest.php
+++ b/tests/src/Command/BundleDependenciesCommandTest.php
@@ -300,4 +300,19 @@ final class BundleDependenciesCommandTest extends Tests\ExtensionFixtureBasedTes
             (string) file_get_contents($rootPath.'/libs/sbom.json'),
         );
     }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\WithoutErrorHandler]
+    public function executeUsesBackupSourcesOptionFromCommandOption(): void
+    {
+        $rootPath = $this->createTemporaryFixture();
+
+        $this->commandTester->execute([
+            '--config' => $rootPath.'/typo3-vendor-bundler.yaml',
+            '--backup-sources' => false,
+            '--overwrite' => true,
+        ]);
+
+        self::assertFileDoesNotExist($rootPath.'/composer.json.bak');
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--backup-sources` / `-b` CLI option to the bundle-dependencies command for backing up source files during dependency processing.
  * New `dependencies.backupSources` configuration option (defaults to false) to control automatic source file backup behavior.

* **Documentation**
  * Updated CLI documentation for the new backup-sources option and its config-based default behavior.
  * Updated configuration schema documentation with the new dependencies.backupSources field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->