### PR TITLE
[TASK] Drop support for Symfony v5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
 		"cyclonedx/cyclonedx-library": "^4.0",
 		"eliashaeussler/task-runner": "^1.0.1",
 		"package-url/packageurl-php": "^1.0",
-		"symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-		"symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-		"symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
+		"symfony/console": "^6.4 || ^7.0 || ^8.0",
+		"symfony/filesystem": "^6.4 || ^7.0 || ^8.0",
+		"symfony/yaml": "^6.4 || ^7.0 || ^8.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8d98087c4ee38f3efdf4524cbce610b",
+    "content-hash": "0684f6d40888e55a8a6d30b0564af89e",
     "packages": [
         {
             "name": "cuyz/valinor",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Symfony version requirements to 6.4 or higher. Versions 5.x are no longer supported. Ensure your environment is running Symfony 6.4, 7.0, or 8.0 to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->