### PR TITLE
[FEATURE] Support `Package.providesPackages` extra section in autoload bundler

### DIFF
--- a/build/tests/.gitignore
+++ b/build/tests/.gitignore
@@ -1,1 +1,2 @@
 /coverage
+/.phpunit.result.cache

--- a/docs/bundlers/autoload.md
+++ b/docs/bundlers/autoload.md
@@ -14,20 +14,26 @@ with dependency injection.
 > [!NOTE]
 > This bundler supports [automatic dependency extraction](../extract.md).
 
-Uses Composer's native dependency management tools to **extract configured `autoload`
-configurations** from both root `composer.json` file and `composer.json` file within
-path to vendor libraries, e.g. `Resources/Private/Libs/composer.json`. Once class
-maps, PSR-4 namespaces and autoload files are loaded, they are merged and dumped to
-the root `composer.json` file. This makes all autoloaded classes and files available
-to TYPO3's autoloader in classic mode.
+The concrete behavior of this bundler depends on the required TYPO3 versions, as
+defined in the root `composer.json` file.
 
-The configured path to vendor libraries will be written as `extra` property to the
-configured root `composer.json` file like follows:
+### Modern: Extensions supporting TYPO3 >= 14.2 only
+
+When using a version constraint like `"typo3/cms-core": "^14.3"`, the "modern" approach
+automatically applies. It extracts all vendor libraries from the `composer.json` file
+within path to vendor libraries, e.g. `Resources/Private/Libs/composer.json` and
+dumps them together with the resolved vendor path to the root `composer.json` file –
+along with the configured path to vendor libraries:
 
 ```json
 {
     "extra": {
         "typo3/cms": {
+            "Package": {
+                "providesPackages": {
+                    "foo/baz": "Resources/Private/Libs/vendor"
+                }
+            },
             "vendor-libraries": {
                 "root-path": "Resources/Private/Libs"
             }
@@ -35,6 +41,42 @@ configured root `composer.json` file like follows:
     }
 }
 ```
+
+### Legacy: Extensions supporting TYPO3 < 14.2
+
+As soon as the extension declares support for TYPO3 < 14.2, e.g. by using a constraint
+like `"typo3/cms-core": "^13.4 || ^14.3"`, the "legacy" approach applies. It uses
+Composer's native dependency management tools to **extract configured `autoload`
+configurations** from both root `composer.json` file and `composer.json` file within
+path to vendor libraries, e.g. `Resources/Private/Libs/composer.json`. Once class
+maps, PSR-4 namespaces and autoload files are loaded, they are merged and dumped to
+the root `composer.json` file. This makes all autoloaded classes and files available
+to TYPO3's autoloader in classic mode.
+
+The configured path to vendor libraries will be written as `extra` property to the
+configured root `composer.json` file, along with the resolved vendor libraries with
+an empty path (this avoids multiple autoload attempts by TYPO3):
+
+```json
+{
+    "extra": {
+        "typo3/cms": {
+            "Package": {
+                "providesPackages": {
+                    "foo/baz": ""
+                }
+            },
+            "vendor-libraries": {
+                "root-path": "Resources/Private/Libs"
+            }
+        }
+    }
+}
+```
+
+> [!NOTE]
+> Read more about the behavior of `providesPackages` in the
+> [official documentation](https://docs.typo3.org/permalink/t3coreapi:ext-composer-json-property-provides-packages).
 
 ## Configuration options
 
@@ -45,6 +87,78 @@ The bundler's behavior can be controlled in various ways:
   `bundle-autoload` command.
 
 ## Example
+
+### Modern approach
+
+Given the following root `composer.json` file:
+
+```json
+{
+    "name": "eliashaeussler/test-extension",
+    "type": "typo3-cms-extension",
+    "require": {
+        "php": "^8.2",
+        "eliashaeussler/cache-warmup": "^5.0",
+        "eliashaeussler/sse": "^2.0",
+        "typo3/cms-backend": "^14.3",
+        "typo3/cms-core": "^14.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "EliasHaeussler\\TestExtension\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_extension"
+        }
+    }
+}
+```
+
+When executing the autoload bundler, it will first use
+[automatic dependency extraction](../extract.md) to extract the `eliashaeussler/cache-warmup`
+and `eliashaeussler/sse` packages as vendor libraries. In the next step, the dumped
+`Resources/Private/Libs/composer.json` file, which defines extracted vendor libraries,
+will be used to install dependencies. Afterwards, the resolved vendor libraries will be
+written into the `extra.typo3/cms.Package.providesPackages` section of the root
+`composer.json` file:
+
+```json
+{
+    "name": "eliashaeussler/test-extension",
+    "type": "typo3-cms-extension",
+    "require": {
+        "php": "^8.2",
+        "eliashaeussler/cache-warmup": "^5.0",
+        "eliashaeussler/sse": "^2.0",
+        "typo3/cms-backend": "^14.3",
+        "typo3/cms-core": "^14.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "EliasHaeussler\\TestExtension\\": "Classes/"
+        }
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "test_extension",
+            "vendor-libraries": {
+                "root-path": "Resources/Private/Libs"
+            },
+            "Package": {
+                "providesPackages": {
+                    "eliashaeussler/cache-warmup": "Resources/Private/Libs/vendor",
+                    "eliashaeussler/sse": "Resources/Private/Libs/vendor"
+                }
+            }
+        }
+    }
+}
+```
+
+
+### Legacy approach
 
 Given the following root `composer.json` file:
 
@@ -72,11 +186,7 @@ Given the following root `composer.json` file:
 }
 ```
 
-When executing the autoload bundler, it will first use
-[automatic dependency extraction](../extract.md) to extract the `eliashaeussler/cache-warmup`
-and `eliashaeussler/sse` packages as vendor libraries. In the next step, the dumped
-`Resources/Private/Libs/composer.json` file, which defines extracted vendor libraries,
-will be used to install dependencies. Afterwards, the resulting autoloads will be merged
+Once the bundler extracted and installed vendor libraries, it merged the resulting autoloads
 into the `autoload` section of the root `composer.json` file:
 
 ```json
@@ -103,6 +213,12 @@ into the `autoload` section of the root `composer.json` file:
             "extension-key": "test_extension",
             "vendor-libraries": {
                 "root-path": "Resources/Private/Libs"
+            },
+            "Package": {
+                "providesPackages": {
+                    "eliashaeussler/cache-warmup": "",
+                    "eliashaeussler/sse": ""
+                }
             }
         }
     }

--- a/src/Bundler/AutoloadBundler.php
+++ b/src/Bundler/AutoloadBundler.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3VendorBundler\Bundler;
 
-use Composer\Composer;
 use Composer\InstalledVersions;
 use Composer\Repository;
+use Composer\Semver;
 use EliasHaeussler\TaskRunner;
 use EliasHaeussler\Typo3VendorBundler\Exception;
 use EliasHaeussler\Typo3VendorBundler\Helper;
@@ -33,6 +33,7 @@ use EliasHaeussler\Typo3VendorBundler\Resource;
 use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
+use function array_key_exists;
 use function array_map;
 use function array_values;
 use function basename;
@@ -87,6 +88,8 @@ final readonly class AutoloadBundler implements Bundler
         bool $backup = false,
         array $excludeFromClassMap = [],
     ): Entity\Autoload {
+        $legacyAutoloading = $this->requiresLegacyAutoloadSupport();
+
         // Extract vendor libraries from root package if necessary
         if ($this->shouldExtractVendorLibrariesFromRootPackage($extractDependencies)) {
             $this->extractVendorLibrariesFromRootPackage($failOnExtractionProblems);
@@ -94,8 +97,23 @@ final readonly class AutoloadBundler implements Bundler
             throw new Exception\DirectoryDoesNotExist($this->librariesPath);
         }
 
+        // Install vendor libraries and build Composer instance
+        $libsComposer = $this->taskRunner->run(
+            '📦 Installing vendor libraries',
+            function (TaskRunner\RunnerContext $context) {
+                $composer = Resource\Composer::create($this->librariesPath);
+                $composer->install(false, $context->output);
+
+                return $composer;
+            },
+        );
+
         // Build autoload bundle from root package and vendor libraries
-        $autoload = $this->parseAutoloads($excludeFromClassMap);
+        if ($legacyAutoloading) {
+            $autoload = $this->parseAutoloads($libsComposer, $excludeFromClassMap);
+        } else {
+            $autoload = Entity\Autoload::stub($this->rootComposer->declarationFile(), $this->rootComposer->rootPath());
+        }
 
         // Create composer.json backup
         if (true === $backup) {
@@ -109,28 +127,48 @@ final readonly class AutoloadBundler implements Bundler
             );
         }
 
-        // Create modified composer.json file contents
-        $this->taskRunner->run(
-            '🎊 Dumping merged autoload configuration',
-            function () use ($autoload) {
-                if (!is_file($autoload->filename())) {
-                    $this->filesystem->copy(
-                        Filesystem\Path::join($this->rootPath, 'composer.json'),
-                        $autoload->filename(),
-                    );
-                }
+        // Create modified composer.json file contents (TYPO3 < 14.2 only)
+        if ($legacyAutoloading) {
+            $this->taskRunner->run(
+                '🎊 Dumping merged autoload configuration',
+                function () use ($autoload) {
+                    if (!is_file($autoload->filename())) {
+                        $this->filesystem->copy(
+                            Filesystem\Path::join($this->rootPath, 'composer.json'),
+                            $autoload->filename(),
+                        );
+                    }
 
-                $configSource = Resource\Composer::create($autoload->filename())->composer->getConfig()->getConfigSource();
-                /* @phpstan-ignore argument.type */
-                $configSource->addProperty('autoload', (object) $autoload->toArray(true));
-            },
+                    $configSource = Resource\Composer::create($autoload->filename())->composer->getConfig()->getConfigSource();
+                    /* @phpstan-ignore argument.type */
+                    $configSource->addProperty('autoload', (object) $autoload->toArray(true));
+                },
+            );
+        }
+
+        // Determine path to vendor/autoload.php (TYPO3 >= 14.2 only)
+        if ($legacyAutoloading) {
+            $autoloadPath = '';
+        } else {
+            $autoloadPath = Filesystem\Path::makeRelative(
+                $libsComposer->composer->getConfig()->get('vendor-dir'),
+                $this->rootPath,
+            );
+        }
+
+        $providedPackages = array_map(
+            static fn () => $autoloadPath,
+            $libsComposer->composer->getPackage()->getRequires(),
         );
 
         // Write metadata to composer.json
-        if (!$this->extraSectionIsPrepared()) {
+        if (!$this->extraSectionIsPrepared() || $this->extraSectionNeedsUpdate('Package.providesPackages', $providedPackages)) {
             $this->taskRunner->run(
                 '✍️ Writing dependency metadata to <comment>composer.json</comment> file',
-                fn () => $this->prepareExtraSection(),
+                function () use ($providedPackages) {
+                    $this->prepareExtraSection();
+                    $this->modifyExtraSection('Package.providesPackages', $providedPackages);
+                },
             );
         }
 
@@ -140,18 +178,8 @@ final readonly class AutoloadBundler implements Bundler
     /**
      * @param list<non-empty-string> $excludeFromClassMap
      */
-    private function parseAutoloads(array $excludeFromClassMap = []): Entity\Autoload
+    private function parseAutoloads(Resource\Composer $libsComposer, array $excludeFromClassMap = []): Entity\Autoload
     {
-        $libsComposer = $this->taskRunner->run(
-            '📦 Installing vendor libraries',
-            function (TaskRunner\RunnerContext $context) {
-                $composer = Resource\Composer::create($this->librariesPath);
-                $composer->install(false, $context->output);
-
-                return $composer;
-            },
-        );
-
         return $this->taskRunner->run(
             '🪄 Parsing autoloads from <comment>composer.json</comment> files',
             function (TaskRunner\RunnerContext $context) use ($libsComposer, $excludeFromClassMap) {
@@ -277,5 +305,22 @@ final readonly class AutoloadBundler implements Bundler
             $filename,
             $rootPath,
         );
+    }
+
+    private function requiresLegacyAutoloadSupport(): bool
+    {
+        $requirements = $this->rootComposer->composer->getPackage()->getRequires();
+        $typo3Constraint = new Semver\Constraint\Constraint('<', '14.2.0');
+
+        foreach (['typo3/cms-core', 'typo3/cms', 'typo3/minimal'] as $packageName) {
+            if (array_key_exists($packageName, $requirements)) {
+                return $requirements[$packageName]->getConstraint()->matches($typo3Constraint);
+            }
+        }
+
+        // Safety net: If we cannot determine the installed TYPO3 version from declared dependencies,
+        // we better assume legacy TYPO3 versions are still supported instead of potentially breaking
+        // things by assuming we have TYPO3 v14.2 only.
+        return true;
     }
 }

--- a/src/Bundler/CanModifyExtraSection.php
+++ b/src/Bundler/CanModifyExtraSection.php
@@ -35,14 +35,20 @@ use Symfony\Component\Filesystem;
  */
 trait CanModifyExtraSection
 {
-    private function modifyExtraSection(string $key, string $value): void
+    /**
+     * @param non-empty-string $key
+     */
+    private function modifyExtraSection(string $key, mixed $value): void
     {
-        $this->rootComposer->writeExtra('typo3/cms.vendor-libraries.'.$key, $value);
+        $this->rootComposer->writeExtra('typo3/cms.'.$key, $value);
     }
 
-    private function extraSectionNeedsUpdate(string $key, string $value): bool
+    /**
+     * @param non-empty-string $key
+     */
+    private function extraSectionNeedsUpdate(string $key, mixed $value): bool
     {
-        $configuredValue = $this->rootComposer->readExtra('typo3/cms.vendor-libraries.'.$key);
+        $configuredValue = $this->rootComposer->readExtra('typo3/cms.'.$key);
 
         return $configuredValue !== $value;
     }
@@ -50,7 +56,7 @@ trait CanModifyExtraSection
     private function prepareExtraSection(): void
     {
         $this->modifyExtraSection(
-            'root-path',
+            'vendor-libraries.root-path',
             Filesystem\Path::makeRelative($this->librariesPath, $this->rootPath),
         );
     }
@@ -58,7 +64,7 @@ trait CanModifyExtraSection
     private function extraSectionIsPrepared(): bool
     {
         return !$this->extraSectionNeedsUpdate(
-            'root-path',
+            'vendor-libraries.root-path',
             Filesystem\Path::makeRelative($this->librariesPath, $this->rootPath),
         );
     }

--- a/src/Bundler/DependencyBundler.php
+++ b/src/Bundler/DependencyBundler.php
@@ -127,7 +127,7 @@ final readonly class DependencyBundler implements Bundler
         // Serialize generated SBOM
         $this->serializeBom($version, $bom, $format, $filename);
 
-        if (!$this->extraSectionIsPrepared() || $this->extraSectionNeedsUpdate('sbom-file', $sbomFile)) {
+        if (!$this->extraSectionIsPrepared() || $this->extraSectionNeedsUpdate('vendor-libraries.sbom-file', $sbomFile)) {
             // Create composer.json backup
             if (true === $backup) {
                 $this->taskRunner->run(
@@ -145,7 +145,7 @@ final readonly class DependencyBundler implements Bundler
                 '✍️ Writing dependency metadata to <comment>composer.json</comment> file',
                 function () use ($sbomFile) {
                     $this->prepareExtraSection();
-                    $this->modifyExtraSection('sbom-file', $sbomFile);
+                    $this->modifyExtraSection('vendor-libraries.sbom-file', $sbomFile);
                 },
             );
         }

--- a/src/Bundler/Entity/Autoload.php
+++ b/src/Bundler/Entity/Autoload.php
@@ -51,6 +51,11 @@ final readonly class Autoload implements MergeableBundle
         $this->filename = Filesystem\Path::makeAbsolute($filename, $this->rootPath);
     }
 
+    public static function stub(string $filename, string $rootPath): self
+    {
+        return new self(null, null, null, $filename, $rootPath);
+    }
+
     /**
      * @return array{
      *     classmap?: list<string>,

--- a/src/Resource/Composer.php
+++ b/src/Resource/Composer.php
@@ -114,7 +114,10 @@ final readonly class Composer
         return $currentSegment[$lastSegment] ?? null;
     }
 
-    public function writeExtra(string $path, string $value): void
+    /**
+     * @param non-empty-string $path
+     */
+    public function writeExtra(string $path, mixed $value): void
     {
         $extra = $this->composer->getPackage()->getExtra();
         $currentSegment = &$extra;

--- a/tests/Bundler/AutoloadBundlerTest.php
+++ b/tests/Bundler/AutoloadBundlerTest.php
@@ -83,11 +83,27 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
         self::assertStringContainsString('🔎 Extracting vendor libraries from root package... Done', $output);
         self::assertStringContainsString('✍️ Creating composer.json file for extracted vendor libraries... Done', $output);
 
-        $actual = $this->parseComposerJson($librariesPath.'/composer.json');
-        $requires = $actual->getRequires();
+        $actualLibsComposer = $this->parseComposerJson($librariesPath.'/composer.json');
+        $actualRootComposer = $this->parseComposerJson($rootPath.'/composer.json');
+        $requires = $actualLibsComposer->getRequires();
 
         self::assertCount(1, $requires);
         self::assertArrayHasKey('eliashaeussler/sse', $requires);
+        self::assertSame(
+            [
+                'typo3/cms' => [
+                    'vendor-libraries' => [
+                        'root-path' => 'libs',
+                    ],
+                    'Package' => [
+                        'providesPackages' => [
+                            'eliashaeussler/sse' => 'libs/vendor',
+                        ],
+                    ],
+                ],
+            ],
+            $actualRootComposer->getExtra(),
+        );
     }
 
     #[Framework\Attributes\Test]
@@ -219,7 +235,7 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
 
     #[Framework\Attributes\Test]
     #[Framework\Attributes\WithoutErrorHandler]
-    public function bundleDumpsMergedAutoloadConfiguration(): void
+    public function bundleDumpsMergedAutoloadConfigurationOnLegacyTypo3Versions(): void
     {
         $composerJson = $this->rootPath.'/composer.json';
 
@@ -231,6 +247,7 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
             self::assertStringContainsString('📦 Installing vendor libraries... Done', $output);
             self::assertStringContainsString('🪄 Parsing autoloads from composer.json files... Done', $output);
             self::assertStringContainsString('🎊 Dumping merged autoload configuration... Done', $output);
+            self::assertStringContainsString('✍️ Writing dependency metadata to composer.json file... Done', $output);
 
             $actual = $this->parseComposerJson($composerJson);
 
@@ -240,6 +257,61 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
             self::assertGreaterThan(1, count($actual->getAutoload()['psr-4']));
             self::assertIsArray($actual->getAutoload()['files'] ?? null);
             self::assertGreaterThan(2, count($actual->getAutoload()['files']));
+            self::assertSame(
+                [
+                    'typo3/cms' => [
+                        'extension-key' => 'test',
+                        'vendor-libraries' => [
+                            'root-path' => 'libs',
+                        ],
+                        'Package' => [
+                            'providesPackages' => [
+                                'symfony/yaml' => '',
+                            ],
+                        ],
+                    ],
+                ],
+                $actual->getExtra(),
+            );
+        }
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\WithoutErrorHandler]
+    public function bundleSkipsAutoloadDumpOnModernTypo3Versions(): void
+    {
+        $rootPath = $this->createTemporaryFixture('valid-modern');
+        $composerJson = $rootPath.'/composer.json';
+
+        try {
+            $this->createSubject($rootPath)->bundle();
+        } finally {
+            $output = $this->output->fetch();
+
+            self::assertStringContainsString('📦 Installing vendor libraries... Done', $output);
+            self::assertStringNotContainsString('🪄 Parsing autoloads from composer.json files... Done', $output);
+            self::assertStringNotContainsString('🎊 Dumping merged autoload configuration... Done', $output);
+            self::assertStringContainsString('✍️ Writing dependency metadata to composer.json file... Done', $output);
+
+            $actual = $this->parseComposerJson($composerJson);
+
+            self::assertSame([], $actual->getAutoload());
+            self::assertSame(
+                [
+                    'typo3/cms' => [
+                        'extension-key' => 'test',
+                        'vendor-libraries' => [
+                            'root-path' => 'libs',
+                        ],
+                        'Package' => [
+                            'providesPackages' => [
+                                'symfony/yaml' => 'libs/vendor',
+                            ],
+                        ],
+                    ],
+                ],
+                $actual->getExtra(),
+            );
         }
     }
 
@@ -262,6 +334,11 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
                 'extension-key' => 'test',
                 'vendor-libraries' => [
                     'root-path' => 'libs',
+                ],
+                'Package' => [
+                    'providesPackages' => [
+                        'symfony/yaml' => '',
+                    ],
                 ],
             ];
 

--- a/tests/Fixtures/Extensions/valid-modern/composer.json
+++ b/tests/Fixtures/Extensions/valid-modern/composer.json
@@ -1,0 +1,10 @@
+{
+	"require": {
+		"typo3/cms-core": "^14.3"
+	},
+	"extra": {
+		"typo3/cms": {
+			"extension-key": "test"
+		}
+	}
+}

--- a/tests/Fixtures/Extensions/valid-modern/libs/composer.json
+++ b/tests/Fixtures/Extensions/valid-modern/libs/composer.json
@@ -1,0 +1,8 @@
+{
+	"require": {
+		"symfony/yaml": "*"
+	},
+	"require-dev": {
+		"symfony/event-dispatcher-contracts": "*"
+	}
+}

--- a/tests/Fixtures/Extensions/valid-modern/typo3-vendor-bundler.yaml
+++ b/tests/Fixtures/Extensions/valid-modern/typo3-vendor-bundler.yaml
@@ -1,0 +1,1 @@
+pathToVendorLibraries: 'libs'

--- a/tests/Fixtures/Extensions/valid-no-libs/composer.json
+++ b/tests/Fixtures/Extensions/valid-no-libs/composer.json
@@ -3,6 +3,6 @@
 		"php": "^8.1",
 		"eliashaeussler/sse": "*",
 		"symfony/console": "*",
-		"typo3/cms-core": "*"
+		"typo3/cms-core": "^14.3"
 	}
 }

--- a/tests/Resource/ComposerTest.php
+++ b/tests/Resource/ComposerTest.php
@@ -227,6 +227,7 @@ final class ComposerTest extends Tests\ExtensionFixtureBasedTestCase
     }
 
     /**
+     * @param non-empty-string     $path
      * @param array<string, mixed> $expected
      */
     #[Framework\Attributes\Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autoload bundling now adapts to modern vs. legacy TYPO3 versions, including smarter Composer metadata output for vendor libraries.
* **Documentation**
  * Updated bundler documentation with clearer modern/legacy behavior, updated examples, and a note for TYPO3 package-provides configuration.
* **Bug Fixes**
  * Corrected the Composer extra-section key used for SBOM file path metadata.
* **Tests**
  * Strengthened autoload/metadata assertions and added/updated fixtures for modern scenarios.
* **Chores**
  * Ignored PHPUnit’s result cache in build test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->