### PR TITLE
[BUGFIX] Consider transitive dependencies in `Package.providesPackages`

### DIFF
--- a/src/Bundler/AutoloadBundler.php
+++ b/src/Bundler/AutoloadBundler.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3VendorBundler\Bundler;
 
 use Composer\InstalledVersions;
+use Composer\Package\BasePackage;
 use Composer\Repository;
 use Composer\Semver;
 use EliasHaeussler\TaskRunner;
@@ -33,6 +34,7 @@ use EliasHaeussler\Typo3VendorBundler\Resource;
 use Symfony\Component\Console;
 use Symfony\Component\Filesystem;
 
+use function array_fill_keys;
 use function array_key_exists;
 use function array_map;
 use function array_values;
@@ -156,10 +158,12 @@ final readonly class AutoloadBundler implements Bundler
             );
         }
 
-        $providedPackages = array_map(
-            static fn () => $autoloadPath,
-            $libsComposer->composer->getPackage()->getRequires(),
+        $packageNames = array_map(
+            static fn (BasePackage $package) => $package->getPrettyName(),
+            $libsComposer->composer->getRepositoryManager()->getLocalRepository()->getPackages(),
         );
+        sort($packageNames);
+        $providedPackages = array_fill_keys($packageNames, $autoloadPath);
 
         // Write metadata to composer.json
         if (!$this->extraSectionIsPrepared() || $this->extraSectionNeedsUpdate('Package.providesPackages', $providedPackages)) {

--- a/tests/Bundler/AutoloadBundlerTest.php
+++ b/tests/Bundler/AutoloadBundlerTest.php
@@ -98,6 +98,7 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
                     'Package' => [
                         'providesPackages' => [
                             'eliashaeussler/sse' => 'libs/vendor',
+                            'php-http/discovery' => 'libs/vendor',
                         ],
                     ],
                 ],
@@ -257,22 +258,10 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
             self::assertGreaterThan(1, count($actual->getAutoload()['psr-4']));
             self::assertIsArray($actual->getAutoload()['files'] ?? null);
             self::assertGreaterThan(2, count($actual->getAutoload()['files']));
-            self::assertSame(
-                [
-                    'typo3/cms' => [
-                        'extension-key' => 'test',
-                        'vendor-libraries' => [
-                            'root-path' => 'libs',
-                        ],
-                        'Package' => [
-                            'providesPackages' => [
-                                'symfony/yaml' => '',
-                            ],
-                        ],
-                    ],
-                ],
-                $actual->getExtra(),
-            );
+            self::assertIsArray($actual->getExtra()['typo3/cms'] ?? null);
+            self::assertIsArray($actual->getExtra()['typo3/cms']['Package'] ?? null);
+            self::assertIsArray($actual->getExtra()['typo3/cms']['Package']['providesPackages'] ?? null);
+            self::assertSame('', $actual->getExtra()['typo3/cms']['Package']['providesPackages']['symfony/yaml'] ?? null);
         }
     }
 
@@ -295,23 +284,13 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
 
             $actual = $this->parseComposerJson($composerJson);
 
+            $extra = $actual->getExtra();
+
             self::assertSame([], $actual->getAutoload());
-            self::assertSame(
-                [
-                    'typo3/cms' => [
-                        'extension-key' => 'test',
-                        'vendor-libraries' => [
-                            'root-path' => 'libs',
-                        ],
-                        'Package' => [
-                            'providesPackages' => [
-                                'symfony/yaml' => 'libs/vendor',
-                            ],
-                        ],
-                    ],
-                ],
-                $actual->getExtra(),
-            );
+            self::assertIsArray($actual->getExtra()['typo3/cms'] ?? null);
+            self::assertIsArray($actual->getExtra()['typo3/cms']['Package'] ?? null);
+            self::assertIsArray($actual->getExtra()['typo3/cms']['Package']['providesPackages'] ?? null);
+            self::assertSame('libs/vendor', $actual->getExtra()['typo3/cms']['Package']['providesPackages']['symfony/yaml'] ?? null);
         }
     }
 
@@ -336,15 +315,22 @@ final class AutoloadBundlerTest extends Tests\ExtensionFixtureBasedTestCase
                     'root-path' => 'libs',
                 ],
                 'Package' => [
-                    'providesPackages' => [
-                        'symfony/yaml' => '',
-                    ],
+                    'providesPackages' => [],
                 ],
             ];
 
             $actual = $this->parseComposerJson($composerJson);
 
-            self::assertSame($expected, $actual->getExtra()['typo3/cms'] ?? null);
+            $extra = $actual->getExtra();
+
+            self::assertIsArray($extra['typo3/cms'] ?? null);
+            self::assertIsArray($extra['typo3/cms']['Package'] ?? null);
+            self::assertIsArray($extra['typo3/cms']['Package']['providesPackages'] ?? null);
+            self::assertSame('', $extra['typo3/cms']['Package']['providesPackages']['symfony/yaml'] ?? null);
+
+            $extra['typo3/cms']['Package']['providesPackages'] = [];
+
+            self::assertSame($expected, $extra['typo3/cms']);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package metadata generation so installed packages are listed accurately and alphabetically.
  * Ensured each provided package is associated with the correct autoload path.
  * Updated metadata handling for packages with empty or non-standard autoload paths.

* **Tests**
  * Expanded coverage for generated package metadata across multiple bundling scenarios.
  * Added validation for package entries and autoload path mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->